### PR TITLE
Sol 37 bug fixes and adjustments

### DIFF
--- a/SolStandard/Containers/Contexts/DeploymentContext.cs
+++ b/SolStandard/Containers/Contexts/DeploymentContext.cs
@@ -30,7 +30,7 @@ namespace SolStandard.Containers.Contexts
             this.map = map;
             CurrentTurn = firstTurn;
             currentUnit = GetArmy(CurrentTurn).First();
-            DeploymentView = new DeploymentView(blueArmy, redArmy, currentUnit);
+            DeploymentView = new DeploymentView(blueArmy, redArmy, currentUnit, GameContext.Scenario);
             MoveToNextDeploymentTile();
         }
 

--- a/SolStandard/Containers/Contexts/GameContext.cs
+++ b/SolStandard/Containers/Contexts/GameContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using SolStandard.Containers.Contexts.WinConditions;
 using SolStandard.Containers.View;
+using SolStandard.Entity.General;
 using SolStandard.Entity.Unit;
 using SolStandard.Map;
 using SolStandard.Map.Camera;
@@ -212,6 +213,8 @@ namespace SolStandard.Containers.Contexts
 
         public static void LoadMapSelect()
         {
+            Bank.ResetBank();
+            
             const string mapPath = MapDirectory + MapSelectFile;
 
             TmxMapParser mapParser = new TmxMapParser(

--- a/SolStandard/Containers/View/DeploymentView.cs
+++ b/SolStandard/Containers/View/DeploymentView.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using SolStandard.Containers.Contexts.WinConditions;
 using SolStandard.Entity;
 using SolStandard.Entity.Unit;
 using SolStandard.HUD.Window;
@@ -29,15 +30,19 @@ namespace SolStandard.Containers.View
 
         public Window ItemDetailWindow { get; private set; }
 
+        public Window ObjectiveWindow { get; private set; }
+
         private Window EntityWindow { get; set; }
 
         private Window HelpText { get; set; }
 
-        public DeploymentView(List<GameUnit> blueArmy, List<GameUnit> redArmy, GameUnit currentUnit)
+        public DeploymentView(List<GameUnit> blueArmy, List<GameUnit> redArmy, GameUnit currentUnit, Scenario scenario)
         {
             visible = true;
 
             UpdateRosterLists(blueArmy, redArmy, currentUnit);
+
+            ObjectiveWindow = scenario.ScenarioInfo(HorizontalAlignment.Centered);
 
             HelpText = GenerateHelpTextWindow();
         }
@@ -230,6 +235,17 @@ namespace SolStandard.Containers.View
             }
         }
 
+        private Vector2 ObjectiveWindowPosition
+        {
+            get
+            {
+                return new Vector2(
+                    (GameDriver.ScreenSize.X / 2) - ((float) ObjectiveWindow.Width / 2),
+                    WindowEdgePadding
+                );
+            }
+        }
+
         #endregion
 
         //Show current unit being deployed
@@ -240,6 +256,8 @@ namespace SolStandard.Containers.View
 
         public void Draw(SpriteBatch spriteBatch)
         {
+            if (ObjectiveWindow != null) ObjectiveWindow.Draw(spriteBatch, ObjectiveWindowPosition);
+
             if (BlueDeployRoster != null) BlueDeployRoster.Draw(spriteBatch, BlueDeployRosterPosition);
             if (RedDeployRoster != null) RedDeployRoster.Draw(spriteBatch, RedDeployRosterPosition);
             if (HelpText != null) HelpText.Draw(spriteBatch, HelpTextPosition);

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -2231,22 +2231,22 @@
     <property name="quantities" value="3|3|3|3|3|3|10"/>
    </properties>
   </object>
-  <object id="900" name="Tower Base" type="BuffTile" gid="6611" x="480" y="160" width="32" height="32">
+  <object id="900" name="Power Rune" type="BuffTile" gid="6611" x="480" y="160" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="901" name="Fort" type="BuffTile" gid="6619" x="512" y="160" width="32" height="32">
+  <object id="901" name="Counter Rune" type="BuffTile" gid="6619" x="512" y="160" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="902" name="House" type="BuffTile" gid="6615" x="576" y="160" width="32" height="32">
+  <object id="902" name="Fortune Rune" type="BuffTile" gid="6615" x="576" y="160" width="32" height="32">
    <properties>
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="903" name="Armor Rack" type="BuffTile" gid="6607" x="544" y="160" width="32" height="32">
+  <object id="903" name="Stalwart Rune" type="BuffTile" gid="6607" x="544" y="160" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="10" nextobjectid="904">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="10" nextobjectid="915">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -2131,7 +2131,7 @@
     <property name="item" value="Sandbag"/>
    </properties>
   </object>
-  <object id="810" name="LadderBridge Chest" type="Chest" gid="6544" x="320" y="416" width="32" height="32">
+  <object id="810" name="LadderBridge Chest" type="Chest" gid="6544" x="256" y="544" width="32" height="32">
    <properties>
     <property name="itemPool" value="LadderBridge"/>
    </properties>
@@ -2186,12 +2186,12 @@
     <property name="amrPerTurn" type="int" value="1"/>
    </properties>
   </object>
-  <object id="853" name="LadderBridge Chest" type="Chest" gid="6544" x="320" y="512" width="32" height="32">
+  <object id="853" name="LadderBridge Chest" type="Chest" gid="6544" x="256" y="576" width="32" height="32">
    <properties>
     <property name="itemPool" value="LadderBridge"/>
    </properties>
   </object>
-  <object id="856" name="Ladder Chest" type="Chest" gid="6544" x="416" y="416" width="32" height="32">
+  <object id="856" name="Ladder Chest" type="Chest" gid="6544" x="384" y="512" width="32" height="32">
    <properties>
     <property name="item" value="Ladder"/>
     <property name="itemPool" value=""/>
@@ -2249,6 +2249,62 @@
   <object id="903" name="Stalwart Rune" type="BuffTile" gid="6607" x="544" y="160" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="904" name="Bomb Chest" type="Chest" gid="6544" x="480" y="288" width="32" height="32">
+   <properties>
+    <property name="item" value="Giant Bomb"/>
+   </properties>
+  </object>
+  <object id="905" name="Rubble" type="BreakableObstacle" gid="6593" x="320" y="288" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="5"/>
+   </properties>
+  </object>
+  <object id="906" name="Rubble" type="BreakableObstacle" gid="6593" x="416" y="224" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="5"/>
+   </properties>
+  </object>
+  <object id="907" name="Rubble" type="BreakableObstacle" gid="6593" x="512" y="256" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="5"/>
+   </properties>
+  </object>
+  <object id="908" name="Rubble" type="BreakableObstacle" gid="6593" x="480" y="320" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="5"/>
+   </properties>
+  </object>
+  <object id="909" name="Rubble" type="BreakableObstacle" gid="6593" x="352" y="320" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="5"/>
+   </properties>
+  </object>
+  <object id="910" name="Bomb Chest" type="Chest" gid="6544" x="384" y="224" width="32" height="32">
+   <properties>
+    <property name="item" value="Giant Bomb"/>
+   </properties>
+  </object>
+  <object id="911" name="Bomb Chest" type="Chest" gid="6544" x="384" y="352" width="32" height="32">
+   <properties>
+    <property name="item" value="Giant Bomb"/>
+   </properties>
+  </object>
+  <object id="912" name="Bomb Chest" type="Chest" gid="6544" x="480" y="352" width="32" height="32">
+   <properties>
+    <property name="item" value="Giant Bomb"/>
+   </properties>
+  </object>
+  <object id="913" name="Bomb Chest" type="Chest" gid="6544" x="320" y="256" width="32" height="32">
+   <properties>
+    <property name="item" value="Giant Bomb"/>
+   </properties>
+  </object>
+  <object id="914" name="Opened Door" type="Door" gid="6579" x="544" y="224" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+    <property name="isOpen" type="bool" value="true"/>
    </properties>
   </object>
  </objectgroup>
@@ -2349,7 +2405,7 @@
   </object>
   <object id="862" name="Giant Bomb" type="Bomb" gid="6495" x="736" y="96" width="32" height="32">
    <properties>
-    <property name="range" value="0,1,2"/>
+    <property name="range" value="0,1,2,3"/>
    </properties>
   </object>
   <object id="864" name="Regular Bomb" type="Bomb" gid="6807" x="736" y="64" width="32" height="32"/>
@@ -2516,17 +2572,17 @@
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="895" name="Arcane Flint" type="RecallCharm" gid="6809" x="480" y="288" width="32" height="32">
+  <object id="895" name="Arcane Flint" type="RecallCharm" gid="6809" x="160" y="160" width="32" height="32">
    <properties>
     <property name="recallId" value="F2"/>
    </properties>
   </object>
-  <object id="896" name="Arcane Flint" type="RecallCharm" gid="6809" x="352" y="288" width="32" height="32">
+  <object id="896" name="Arcane Flint" type="RecallCharm" gid="6809" x="128" y="160" width="32" height="32">
    <properties>
     <property name="recallId" value="Flint1"/>
    </properties>
   </object>
-  <object id="897" name="Arcane Flint" type="RecallCharm" gid="6809" x="416" y="288" width="32" height="32">
+  <object id="897" name="Arcane Flint" type="RecallCharm" gid="6809" x="192" y="160" width="32" height="32">
    <properties>
     <property name="recallId" value="DifferentFlint"/>
    </properties>

--- a/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
@@ -2047,22 +2047,10 @@
   <object id="951" name="Healthy Potion" type="HealthPotion" gid="6759" x="736" y="96" width="32" height="32"/>
  </objectgroup>
  <objectgroup id="8" name="Units">
-  <object id="902" name="Gaius" type="Unit" gid="3" x="576" y="320" width="32" height="32">
+  <object id="902" name="Gaius" type="Unit" gid="3" x="544" y="352" width="32" height="32">
    <properties>
     <property name="Class" value="Champion"/>
     <property name="Commander" type="bool" value="true"/>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="903" name="Ethan" type="Unit" gid="5" x="608" y="320" width="32" height="32">
-   <properties>
-    <property name="Class" value="Lancer"/>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="904" name="Qorf" type="Unit" gid="1" x="576" y="352" width="32" height="32">
-   <properties>
-    <property name="Class" value="Archer"/>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
@@ -2085,22 +2073,10 @@
     <property name="routine_summon.class" value="Deckard"/>
    </properties>
   </object>
-  <object id="909" name="Charlotte" type="Unit" gid="20" x="448" y="320" width="32" height="32">
+  <object id="909" name="Charlotte" type="Unit" gid="20" x="480" y="352" width="32" height="32">
    <properties>
     <property name="Class" value="Paladin"/>
     <property name="Commander" type="bool" value="true"/>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="901" name="Eckhart" type="Unit" gid="12" x="448" y="352" width="32" height="32">
-   <properties>
-    <property name="Class" value="Mage"/>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="907" name="Maria" type="Unit" gid="18" x="416" y="320" width="32" height="32">
-   <properties>
-    <property name="Class" value="Cleric"/>
     <property name="Team" value="Red"/>
    </properties>
   </object>
@@ -2182,6 +2158,30 @@
     <property name="routine_basicAttack" type="bool" value="false"/>
     <property name="routine_glutton" type="bool" value="true"/>
     <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="903" name="Ethan" type="Unit" gid="5" x="608" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Lancer"/>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="904" name="Qorf" type="Unit" gid="1" x="576" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Archer"/>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="901" name="Eckhart" type="Unit" gid="12" x="448" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Mage"/>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="907" name="Maria" type="Unit" gid="18" x="416" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Cleric"/>
+    <property name="Team" value="Red"/>
    </properties>
   </object>
  </objectgroup>

--- a/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
@@ -2066,6 +2066,46 @@
     <property name="Team" value="Blue"/>
    </properties>
   </object>
+  <object id="912" name="Slim Jim" type="Creep" gid="21" x="640" y="224" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Squeezy Jim"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="915" name="Marrowon" type="Creep" gid="25" x="512" y="224" width="32" height="32">
+   <properties>
+    <property name="Class" value="Necromancer"/>
+    <property name="Commander" type="bool" value="true"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Deckard"/>
+   </properties>
+  </object>
+  <object id="909" name="Charlotte" type="Unit" gid="20" x="448" y="320" width="32" height="32">
+   <properties>
+    <property name="Class" value="Paladin"/>
+    <property name="Commander" type="bool" value="true"/>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="901" name="Eckhart" type="Unit" gid="12" x="448" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Mage"/>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="907" name="Maria" type="Unit" gid="18" x="416" y="320" width="32" height="32">
+   <properties>
+    <property name="Class" value="Cleric"/>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="9" name="Disabled" opacity="0.24">
   <object id="952" name="Glom Heckyell" type="Creep" gid="23" x="512" y="320" width="32" height="32">
    <properties>
     <property name="Class" value="Orc"/>
@@ -2104,15 +2144,6 @@
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="912" name="Slim Jim" type="Creep" gid="21" x="640" y="224" width="32" height="32">
-   <properties>
-    <property name="Class" value="Slime"/>
-    <property name="routine_glutton" type="bool" value="true"/>
-    <property name="routine_summon" type="bool" value="true"/>
-    <property name="routine_summon.class" value="Squeezy Jim"/>
-    <property name="routine_treasureHunter" type="bool" value="true"/>
-   </properties>
-  </object>
   <object id="917" name="Qi'Ko" type="Creep" gid="27" x="384" y="224" width="32" height="32">
    <properties>
     <property name="Class" value="Goblin"/>
@@ -2129,16 +2160,6 @@
     <property name="routine_glutton" type="bool" value="true"/>
     <property name="routine_prey" type="bool" value="true"/>
     <property name="routine_triggerHappy" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="915" name="Marrowon" type="Creep" gid="25" x="512" y="224" width="32" height="32">
-   <properties>
-    <property name="Class" value="Necromancer"/>
-    <property name="Commander" type="bool" value="true"/>
-    <property name="routine_defender" type="bool" value="true"/>
-    <property name="routine_prey" type="bool" value="true"/>
-    <property name="routine_summon" type="bool" value="true"/>
-    <property name="routine_summon.class" value="Deckard"/>
    </properties>
   </object>
   <object id="913" name="Carl" type="Creep" gid="22" x="512" y="128" width="32" height="32">
@@ -2163,27 +2184,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="909" name="Charlotte" type="Unit" gid="20" x="448" y="320" width="32" height="32">
-   <properties>
-    <property name="Class" value="Paladin"/>
-    <property name="Commander" type="bool" value="true"/>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="901" name="Eckhart" type="Unit" gid="12" x="448" y="352" width="32" height="32">
-   <properties>
-    <property name="Class" value="Mage"/>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="907" name="Maria" type="Unit" gid="18" x="416" y="320" width="32" height="32">
-   <properties>
-    <property name="Class" value="Cleric"/>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
  </objectgroup>
- <objectgroup id="9" name="Disabled" opacity="0.24"/>
  <layer id="4" name="Overlay" width="32" height="20">
   <data>
    <tile/>

--- a/SolStandard/Content/TmxMaps/Draft_Arena_Dungeon_01.tmx
+++ b/SolStandard/Content/TmxMaps/Draft_Arena_Dungeon_01.tmx
@@ -3127,23 +3127,23 @@
   <object id="884" name="Crate" type="Pushable" gid="254" x="832" y="256" width="32" height="32"/>
   <object id="885" name="Crate" type="Pushable" gid="253" x="864" y="224" width="32" height="32"/>
   <object id="886" name="Crate" type="Pushable" gid="254" x="896" y="256" width="32" height="32"/>
-  <object id="887" name="Chest" type="Chest" gid="234" x="192" y="192" width="32" height="32">
+  <object id="887" name="Money Chest" type="Chest" gid="234" x="192" y="192" width="32" height="32">
    <properties>
     <property name="gold" type="int" value="15"/>
    </properties>
   </object>
-  <object id="888" name="Chest" type="Chest" gid="234" x="704" y="96" width="32" height="32">
+  <object id="888" name="Money Chest" type="Chest" gid="234" x="704" y="96" width="32" height="32">
    <properties>
     <property name="gold" type="int" value="20"/>
    </properties>
   </object>
-  <object id="890" name="Chest" type="Chest" gid="234" x="992" y="704" width="32" height="32">
+  <object id="890" name="Weapon Chest" type="Chest" gid="234" x="992" y="704" width="32" height="32">
    <properties>
     <property name="gold" type="int" value="25"/>
     <property name="itemPool" value="A"/>
    </properties>
   </object>
-  <object id="891" name="Chest" type="Chest" gid="234" x="224" y="672" width="32" height="32">
+  <object id="891" name="Money Chest" type="Chest" gid="234" x="224" y="672" width="32" height="32">
    <properties>
     <property name="gold" type="int" value="15"/>
    </properties>
@@ -3270,7 +3270,7 @@
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="977" name="Chest" type="Chest" gid="234" x="640" y="416" width="32" height="32">
+  <object id="977" name="Weapon Chest" type="Chest" gid="234" x="640" y="416" width="32" height="32">
    <properties>
     <property name="gold" type="int" value="25"/>
     <property name="itemPool" value="A"/>

--- a/SolStandard/Content/TmxMaps/Draft_Master_Control.tmx
+++ b/SolStandard/Content/TmxMaps/Draft_Master_Control.tmx
@@ -1,12 +1,108 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="12" nextobjectid="1113">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="23" tilewidth="32" tileheight="32" infinite="0" nextlayerid="16" nextobjectid="1113">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
  <tileset firstgid="31" source="overworld-32.tsx"/>
  <tileset firstgid="6311" source="entities-32.tsx"/>
- <layer id="1" name="Terrain" width="32" height="20">
+ <layer id="12" name="Terrain" width="32" height="23">
   <data>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
    <tile/>
    <tile/>
    <tile/>
@@ -649,8 +745,104 @@
    <tile/>
   </data>
  </layer>
- <layer id="2" name="TerrainDecoration" width="32" height="20">
+ <layer id="13" name="TerrainDecoration" width="32" height="23">
   <data>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
    <tile/>
    <tile/>
    <tile/>
@@ -1293,8 +1485,104 @@
    <tile/>
   </data>
  </layer>
- <layer id="3" name="Collide" width="32" height="20">
+ <layer id="14" name="Collide" width="32" height="23">
   <data>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
    <tile gid="5566"/>
    <tile gid="5566"/>
    <tile gid="5712"/>
@@ -1938,509 +2226,509 @@
   </data>
  </layer>
  <objectgroup id="5" name="Entities">
-  <object id="954" name="Fire Switch" type="Switch" gid="6595" x="512" y="288" width="32" height="32">
+  <object id="954" name="Fire Switch" type="Switch" gid="6595" x="512" y="384" width="32" height="32">
    <properties>
     <property name="triggersId" value="Flame Trap A"/>
    </properties>
   </object>
-  <object id="956" name="Gate A Switch" type="Switch" gid="6595" x="448" y="352" width="32" height="32">
+  <object id="956" name="Gate A Switch" type="Switch" gid="6595" x="448" y="448" width="32" height="32">
    <properties>
     <property name="triggersId" value="Gate A"/>
    </properties>
   </object>
-  <object id="957" name="Gate B Switch" type="Switch" gid="6595" x="576" y="352" width="32" height="32">
+  <object id="957" name="Gate B Switch" type="Switch" gid="6595" x="576" y="448" width="32" height="32">
    <properties>
     <property name="triggersId" value="Gate B"/>
    </properties>
   </object>
-  <object id="958" name="Debris" type="BreakableObstacle" gid="6591" x="640" y="416" width="32" height="32">
+  <object id="958" name="Debris" type="BreakableObstacle" gid="6591" x="640" y="512" width="32" height="32">
    <properties>
     <property name="HP" type="int" value="1"/>
    </properties>
   </object>
-  <object id="959" name="Debris" type="BreakableObstacle" gid="6591" x="672" y="448" width="32" height="32">
+  <object id="959" name="Debris" type="BreakableObstacle" gid="6591" x="672" y="544" width="32" height="32">
    <properties>
     <property name="HP" type="int" value="1"/>
    </properties>
   </object>
-  <object id="960" name="Cage Gate" type="Door" gid="6581" x="288" y="384" width="32" height="32">
+  <object id="960" name="Cage Gate" type="Door" gid="6581" x="288" y="480" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="961" name="Gate A" type="Door" gid="6571" x="736" y="416" width="32" height="32">
+  <object id="961" name="Gate A" type="Door" gid="6571" x="736" y="512" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="962" name="Gate A" type="Door" gid="6581" x="800" y="480" width="32" height="32">
+  <object id="962" name="Gate A" type="Door" gid="6581" x="800" y="576" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="963" name="Weak Wall" type="BreakableObstacle" gid="5675" x="864" y="352" width="32" height="32">
+  <object id="963" name="Weak Wall" type="BreakableObstacle" gid="5675" x="864" y="448" width="32" height="32">
    <properties>
     <property name="HP" type="int" value="2"/>
    </properties>
   </object>
-  <object id="964" name="Spike Trap A" type="Trap" gid="6587" x="544" y="448" width="32" height="32">
+  <object id="964" name="Spike Trap A" type="Trap" gid="6587" x="544" y="544" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="965" name="Spike Trap A" type="Trap" gid="6587" x="512" y="480" width="32" height="32">
+  <object id="965" name="Spike Trap A" type="Trap" gid="6587" x="512" y="576" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="966" name="Spike Trap B" type="Trap" gid="6587" x="544" y="480" width="32" height="32">
+  <object id="966" name="Spike Trap B" type="Trap" gid="6587" x="544" y="576" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="967" name="Spike Trap B" type="Trap" gid="6587" x="512" y="448" width="32" height="32">
+  <object id="967" name="Spike Trap B" type="Trap" gid="6587" x="512" y="544" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="968" name="Spike Trap B" type="Trap" gid="6587" x="608" y="480" width="32" height="32">
+  <object id="968" name="Spike Trap B" type="Trap" gid="6587" x="608" y="576" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="969" name="Spike Trap B" type="Trap" gid="6587" x="576" y="448" width="32" height="32">
+  <object id="969" name="Spike Trap B" type="Trap" gid="6587" x="576" y="544" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="970" name="Spike Trap A" type="Trap" gid="6587" x="608" y="448" width="32" height="32">
+  <object id="970" name="Spike Trap A" type="Trap" gid="6587" x="608" y="544" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="971" name="Spike Trap A" type="Trap" gid="6587" x="576" y="480" width="32" height="32">
+  <object id="971" name="Spike Trap A" type="Trap" gid="6587" x="576" y="576" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="973" name="Debris" type="BreakableObstacle" gid="5960" x="128" y="192" width="32" height="32">
+  <object id="973" name="Debris" type="BreakableObstacle" gid="5960" x="128" y="288" width="32" height="32">
    <properties>
     <property name="HP" type="int" value="1"/>
    </properties>
   </object>
-  <object id="974" name="Debris" type="BreakableObstacle" gid="5958" x="128" y="224" width="32" height="32">
+  <object id="974" name="Debris" type="BreakableObstacle" gid="5958" x="128" y="320" width="32" height="32">
    <properties>
     <property name="HP" type="int" value="1"/>
    </properties>
   </object>
-  <object id="975" name="Gate A" type="Door" gid="6581" x="704" y="480" width="32" height="32">
+  <object id="975" name="Gate A" type="Door" gid="6581" x="704" y="576" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="976" name="Gate B" type="Door" gid="6571" x="736" y="192" width="32" height="32">
+  <object id="976" name="Gate B" type="Door" gid="6571" x="736" y="288" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="977" name="Gate B" type="Door" gid="6571" x="768" y="192" width="32" height="32">
+  <object id="977" name="Gate B" type="Door" gid="6571" x="768" y="288" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="978" name="Spike Trap B" type="Trap" gid="6587" x="448" y="512" width="32" height="32">
+  <object id="978" name="Spike Trap B" type="Trap" gid="6587" x="448" y="608" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="979" name="Spike Trap B" type="Trap" gid="6587" x="416" y="544" width="32" height="32">
+  <object id="979" name="Spike Trap B" type="Trap" gid="6587" x="416" y="640" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="980" name="Spike Trap A" type="Trap" gid="6587" x="448" y="544" width="32" height="32">
+  <object id="980" name="Spike Trap A" type="Trap" gid="6587" x="448" y="640" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="981" name="Spike Trap A" type="Trap" gid="6587" x="416" y="512" width="32" height="32">
+  <object id="981" name="Spike Trap A" type="Trap" gid="6587" x="416" y="608" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="982" name="Spike Trap A" type="Trap" gid="6587" x="512" y="544" width="32" height="32">
+  <object id="982" name="Spike Trap A" type="Trap" gid="6587" x="512" y="640" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="983" name="Spike Trap A" type="Trap" gid="6587" x="480" y="512" width="32" height="32">
+  <object id="983" name="Spike Trap A" type="Trap" gid="6587" x="480" y="608" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="984" name="Spike Trap B" type="Trap" gid="6587" x="512" y="512" width="32" height="32">
+  <object id="984" name="Spike Trap B" type="Trap" gid="6587" x="512" y="608" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="985" name="Spike Trap B" type="Trap" gid="6587" x="480" y="544" width="32" height="32">
+  <object id="985" name="Spike Trap B" type="Trap" gid="6587" x="480" y="640" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="986" name="Spike Trap A" type="Trap" gid="6587" x="416" y="448" width="32" height="32">
+  <object id="986" name="Spike Trap A" type="Trap" gid="6587" x="416" y="544" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="987" name="Spike Trap B" type="Trap" gid="6587" x="448" y="448" width="32" height="32">
+  <object id="987" name="Spike Trap B" type="Trap" gid="6587" x="448" y="544" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="988" name="Spike Trap A" type="Trap" gid="6587" x="480" y="448" width="32" height="32">
+  <object id="988" name="Spike Trap A" type="Trap" gid="6587" x="480" y="544" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="989" name="Spike Trap B" type="Trap" gid="6587" x="544" y="544" width="32" height="32">
+  <object id="989" name="Spike Trap B" type="Trap" gid="6587" x="544" y="640" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="990" name="Spike Trap A" type="Trap" gid="6587" x="576" y="544" width="32" height="32">
+  <object id="990" name="Spike Trap A" type="Trap" gid="6587" x="576" y="640" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="991" name="Spike Trap B" type="Trap" gid="6587" x="608" y="544" width="32" height="32">
+  <object id="991" name="Spike Trap B" type="Trap" gid="6587" x="608" y="640" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="enabled" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="992" name="Gate B" type="Door" gid="6571" x="192" y="256" width="32" height="32">
+  <object id="992" name="Gate B" type="Door" gid="6571" x="192" y="352" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="993" name="Gate B" type="Door" gid="6571" x="224" y="256" width="32" height="32">
+  <object id="993" name="Gate B" type="Door" gid="6571" x="224" y="352" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="994" name="Push Block" type="Pushable" gid="6637" x="736" y="288" width="32" height="32"/>
-  <object id="995" name="Push Block" type="Pushable" gid="6637" x="640" y="256" width="32" height="32"/>
-  <object id="996" name="Push Block" type="Pushable" gid="6637" x="768" y="320" width="32" height="32"/>
-  <object id="997" name="Push Block" type="Pushable" gid="6637" x="672" y="320" width="32" height="32"/>
-  <object id="999" name="Cage Release" type="PressurePlate" gid="6670" x="512" y="320" width="32" height="32">
+  <object id="994" name="Push Block" type="Pushable" gid="6637" x="736" y="384" width="32" height="32"/>
+  <object id="995" name="Push Block" type="Pushable" gid="6637" x="640" y="352" width="32" height="32"/>
+  <object id="996" name="Push Block" type="Pushable" gid="6637" x="768" y="416" width="32" height="32"/>
+  <object id="997" name="Push Block" type="Pushable" gid="6637" x="672" y="416" width="32" height="32"/>
+  <object id="999" name="Cage Release" type="PressurePlate" gid="6670" x="512" y="416" width="32" height="32">
    <properties>
     <property name="triggersId" value="Cage Gate"/>
    </properties>
   </object>
-  <object id="1000" name="Cage Gate" type="Door" gid="6571" x="224" y="448" width="32" height="32">
+  <object id="1000" name="Cage Gate" type="Door" gid="6571" x="224" y="544" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1001" name="Cage Gate" type="Door" gid="6571" x="256" y="448" width="32" height="32">
+  <object id="1001" name="Cage Gate" type="Door" gid="6571" x="256" y="544" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1002" name="Cage Gate" type="Door" gid="6571" x="256" y="320" width="32" height="32">
+  <object id="1002" name="Cage Gate" type="Door" gid="6571" x="256" y="416" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1003" name="Cage Gate" type="Door" gid="6571" x="224" y="320" width="32" height="32">
+  <object id="1003" name="Cage Gate" type="Door" gid="6571" x="224" y="416" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1004" name="Spike Switch A" type="Switch" gid="6595" x="448" y="384" width="32" height="32">
+  <object id="1004" name="Spike Switch A" type="Switch" gid="6595" x="448" y="480" width="32" height="32">
    <properties>
     <property name="triggersId" value="Spike Trap A"/>
    </properties>
   </object>
-  <object id="1005" name="Spike Switch B" type="Switch" gid="6595" x="576" y="384" width="32" height="32">
+  <object id="1005" name="Spike Switch B" type="Switch" gid="6595" x="576" y="480" width="32" height="32">
    <properties>
     <property name="triggersId" value="Spike Trap B"/>
    </properties>
   </object>
-  <object id="1006" name="Flint Chest" type="Chest" gid="6544" x="768" y="448" width="32" height="32">
+  <object id="1006" name="Flint Chest" type="Chest" gid="6544" x="768" y="544" width="32" height="32">
    <properties>
     <property name="item" value="Arcane Flint"/>
    </properties>
   </object>
-  <object id="1008" name="NE Stairs" type="Portal" gid="6598" x="896" y="64" width="32" height="32">
+  <object id="1008" name="NE Stairs" type="Portal" gid="6598" x="896" y="160" width="32" height="32">
    <properties>
     <property name="destinationId" value="SW Stairs"/>
    </properties>
   </object>
-  <object id="1009" name="NE Stairs" type="Portal" gid="6598" x="864" y="64" width="32" height="32">
+  <object id="1009" name="NE Stairs" type="Portal" gid="6598" x="864" y="160" width="32" height="32">
    <properties>
     <property name="destinationId" value="SW Stairs"/>
    </properties>
   </object>
-  <object id="1010" name="NE Stairs" type="Portal" gid="6598" x="928" y="64" width="32" height="32">
+  <object id="1010" name="NE Stairs" type="Portal" gid="6598" x="928" y="160" width="32" height="32">
    <properties>
     <property name="destinationId" value="SW Stairs"/>
    </properties>
   </object>
-  <object id="1011" name="SW Stairs" type="Portal" gid="6599" x="224" y="576" width="32" height="32">
+  <object id="1011" name="SW Stairs" type="Portal" gid="6599" x="224" y="672" width="32" height="32">
    <properties>
     <property name="destinationId" value="NE Stairs"/>
    </properties>
   </object>
-  <object id="1012" name="SW Stairs" type="Portal" gid="6599" x="256" y="576" width="32" height="32">
+  <object id="1012" name="SW Stairs" type="Portal" gid="6599" x="256" y="672" width="32" height="32">
    <properties>
     <property name="destinationId" value="NE Stairs"/>
    </properties>
   </object>
-  <object id="1013" name="SW Stairs" type="Portal" gid="6599" x="192" y="576" width="32" height="32">
+  <object id="1013" name="SW Stairs" type="Portal" gid="6599" x="192" y="672" width="32" height="32">
    <properties>
     <property name="destinationId" value="NE Stairs"/>
    </properties>
   </object>
-  <object id="1014" name="Flame Trap A" type="Trap" gid="6747" x="736" y="448" width="32" height="32">
+  <object id="1014" name="Flame Trap A" type="Trap" gid="6747" x="736" y="544" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="2"/>
    </properties>
   </object>
-  <object id="1015" name="Flame Trap A" type="Trap" gid="6747" x="736" y="480" width="32" height="32">
+  <object id="1015" name="Flame Trap A" type="Trap" gid="6747" x="736" y="576" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="2"/>
    </properties>
   </object>
-  <object id="1016" name="Flame Trap A" type="Trap" gid="6747" x="768" y="480" width="32" height="32">
+  <object id="1016" name="Flame Trap A" type="Trap" gid="6747" x="768" y="576" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="2"/>
    </properties>
   </object>
-  <object id="1017" name="Power Rune" type="BuffTile" gid="6611" x="352" y="288" width="32" height="32">
+  <object id="1017" name="Power Rune" type="BuffTile" gid="6611" x="352" y="384" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1018" name="Counter Rune" type="BuffTile" gid="6619" x="352" y="416" width="32" height="32">
+  <object id="1018" name="Counter Rune" type="BuffTile" gid="6619" x="352" y="512" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1019" name="Fortune Rune" type="BuffTile" gid="6615" x="224" y="512" width="32" height="32">
+  <object id="1019" name="Fortune Rune" type="BuffTile" gid="6615" x="224" y="608" width="32" height="32">
    <properties>
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1020" name="Fortune Rune" type="BuffTile" gid="6615" x="896" y="256" width="32" height="32">
+  <object id="1020" name="Fortune Rune" type="BuffTile" gid="6615" x="896" y="352" width="32" height="32">
    <properties>
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1021" name="Power Rune" type="BuffTile" gid="6611" x="736" y="96" width="32" height="32">
+  <object id="1021" name="Power Rune" type="BuffTile" gid="6611" x="736" y="192" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1022" name="Counter Rune" type="BuffTile" gid="6619" x="672" y="416" width="32" height="32">
+  <object id="1022" name="Counter Rune" type="BuffTile" gid="6619" x="672" y="512" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1027" name="Blue Deploy" type="Deployment" gid="6342" x="864" y="416" width="32" height="32">
+  <object id="1027" name="Blue Deploy" type="Deployment" gid="6342" x="864" y="512" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="1028" name="Red Deploy" type="Deployment" gid="6350" x="160" y="64" width="32" height="32">
+  <object id="1028" name="Red Deploy" type="Deployment" gid="6350" x="160" y="160" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="1029" name="Red Deploy" type="Deployment" gid="6350" x="224" y="64" width="32" height="32">
+  <object id="1029" name="Red Deploy" type="Deployment" gid="6350" x="224" y="160" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="1030" name="Red Deploy" type="Deployment" gid="6350" x="224" y="128" width="32" height="32">
+  <object id="1030" name="Red Deploy" type="Deployment" gid="6350" x="224" y="224" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="1031" name="Red Deploy" type="Deployment" gid="6350" x="256" y="96" width="32" height="32">
+  <object id="1031" name="Red Deploy" type="Deployment" gid="6350" x="256" y="192" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="1032" name="Red Deploy" type="Deployment" gid="6350" x="192" y="96" width="32" height="32">
+  <object id="1032" name="Red Deploy" type="Deployment" gid="6350" x="192" y="192" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="1033" name="Red Deploy" type="Deployment" gid="6350" x="160" y="128" width="32" height="32">
+  <object id="1033" name="Red Deploy" type="Deployment" gid="6350" x="160" y="224" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="1034" name="Blue Deploy" type="Deployment" gid="6342" x="896" y="448" width="32" height="32">
+  <object id="1034" name="Blue Deploy" type="Deployment" gid="6342" x="896" y="544" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="1035" name="Blue Deploy" type="Deployment" gid="6342" x="864" y="480" width="32" height="32">
+  <object id="1035" name="Blue Deploy" type="Deployment" gid="6342" x="864" y="576" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="1036" name="Blue Deploy" type="Deployment" gid="6342" x="896" y="512" width="32" height="32">
+  <object id="1036" name="Blue Deploy" type="Deployment" gid="6342" x="896" y="608" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="1037" name="Blue Deploy" type="Deployment" gid="6342" x="832" y="448" width="32" height="32">
+  <object id="1037" name="Blue Deploy" type="Deployment" gid="6342" x="832" y="544" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="1038" name="Blue Deploy" type="Deployment" gid="6342" x="832" y="512" width="32" height="32">
+  <object id="1038" name="Blue Deploy" type="Deployment" gid="6342" x="832" y="608" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="1039" name="Counter Rune" type="BuffTile" gid="6619" x="416" y="128" width="32" height="32">
+  <object id="1039" name="Counter Rune" type="BuffTile" gid="6619" x="416" y="224" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1040" name="Power Rune" type="BuffTile" gid="6611" x="640" y="448" width="32" height="32">
+  <object id="1040" name="Power Rune" type="BuffTile" gid="6611" x="640" y="544" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1041" name="Power Rune" type="BuffTile" gid="6611" x="864" y="288" width="32" height="32">
+  <object id="1041" name="Power Rune" type="BuffTile" gid="6611" x="864" y="384" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1042" name="Fortune Rune" type="BuffTile" gid="6615" x="800" y="128" width="32" height="32">
+  <object id="1042" name="Fortune Rune" type="BuffTile" gid="6615" x="800" y="224" width="32" height="32">
    <properties>
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1044" name="Fortune Rune" type="BuffTile" gid="6615" x="544" y="192" width="32" height="32">
+  <object id="1044" name="Fortune Rune" type="BuffTile" gid="6615" x="544" y="288" width="32" height="32">
    <properties>
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1045" name="Counter Rune" type="BuffTile" gid="6619" x="64" y="320" width="32" height="32">
+  <object id="1045" name="Counter Rune" type="BuffTile" gid="6619" x="64" y="416" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1046" name="Power Rune" type="BuffTile" gid="6611" x="320" y="128" width="32" height="32">
+  <object id="1046" name="Power Rune" type="BuffTile" gid="6611" x="320" y="224" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1047" name="Power Rune" type="BuffTile" gid="6611" x="96" y="384" width="32" height="32">
+  <object id="1047" name="Power Rune" type="BuffTile" gid="6611" x="96" y="480" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1048" name="Counter Rune" type="BuffTile" gid="6619" x="224" y="192" width="32" height="32">
+  <object id="1048" name="Counter Rune" type="BuffTile" gid="6619" x="224" y="288" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1049" name="Counter Rune" type="BuffTile" gid="6619" x="736" y="576" width="32" height="32">
+  <object id="1049" name="Counter Rune" type="BuffTile" gid="6619" x="736" y="672" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1051" name="Stalwart Rune" type="BuffTile" gid="6607" x="352" y="352" width="32" height="32">
+  <object id="1051" name="Stalwart Rune" type="BuffTile" gid="6607" x="352" y="448" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1052" name="Stalwart Rune" type="BuffTile" gid="6607" x="640" y="96" width="32" height="32">
+  <object id="1052" name="Stalwart Rune" type="BuffTile" gid="6607" x="640" y="192" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1053" name="Stalwart Rune" type="BuffTile" gid="6607" x="64" y="448" width="32" height="32">
+  <object id="1053" name="Stalwart Rune" type="BuffTile" gid="6607" x="64" y="544" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1054" name="Stalwart Rune" type="BuffTile" gid="6607" x="640" y="512" width="32" height="32">
+  <object id="1054" name="Stalwart Rune" type="BuffTile" gid="6607" x="640" y="608" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1097" name="Debris" type="BreakableObstacle" gid="5960" x="480" y="288" width="32" height="32">
+  <object id="1097" name="Debris" type="BreakableObstacle" gid="5960" x="480" y="384" width="32" height="32">
    <properties>
     <property name="HP" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1098" name="Debris" type="BreakableObstacle" gid="5960" x="544" y="288" width="32" height="32">
+  <object id="1098" name="Debris" type="BreakableObstacle" gid="5960" x="544" y="384" width="32" height="32">
    <properties>
     <property name="HP" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1102" name="Bomb Chest" type="Chest" gid="6544" x="928" y="320" width="32" height="32">
+  <object id="1102" name="Bomb Chest" type="Chest" gid="6544" x="928" y="416" width="32" height="32">
    <properties>
     <property name="item" value="Bomb"/>
    </properties>
   </object>
-  <object id="1103" name="Bomb Chest" type="Chest" gid="6544" x="64" y="224" width="32" height="32">
+  <object id="1103" name="Bomb Chest" type="Chest" gid="6544" x="64" y="320" width="32" height="32">
    <properties>
     <property name="item" value="Bomb"/>
    </properties>
   </object>
-  <object id="1104" name="Stalwart Rune" type="BuffTile" gid="6607" x="384" y="512" width="32" height="32">
+  <object id="1104" name="Stalwart Rune" type="BuffTile" gid="6607" x="384" y="608" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1105" name="Power Rune" type="BuffTile" gid="6611" x="384" y="544" width="32" height="32">
+  <object id="1105" name="Power Rune" type="BuffTile" gid="6611" x="384" y="640" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1106" name="Bank" type="Bank" gid="6536" x="864" y="224" width="32" height="32"/>
-  <object id="1107" name="Bank" type="Bank" gid="6536" x="96" y="320" width="32" height="32"/>
-  <object id="1108" name="Bank" type="Bank" gid="6536" x="416" y="192" width="32" height="32"/>
-  <object id="1109" name="Bank" type="Bank" gid="6536" x="672" y="512" width="32" height="32"/>
-  <object id="1110" name="Contract Vendor" type="Vendor" gid="6535" x="192" y="192" width="32" height="32">
+  <object id="1106" name="Bank" type="Bank" gid="6536" x="864" y="320" width="32" height="32"/>
+  <object id="1107" name="Bank" type="Bank" gid="6536" x="96" y="416" width="32" height="32"/>
+  <object id="1108" name="Bank" type="Bank" gid="6536" x="416" y="288" width="32" height="32"/>
+  <object id="1109" name="Bank" type="Bank" gid="6536" x="672" y="608" width="32" height="32"/>
+  <object id="1110" name="Contract Vendor" type="Vendor" gid="6535" x="192" y="288" width="32" height="32">
    <properties>
     <property name="items" value="Free Contract"/>
     <property name="prices" value="100"/>
     <property name="quantities" value="3"/>
    </properties>
   </object>
-  <object id="1112" name="Contract Vendor" type="Vendor" gid="6535" x="768" y="576" width="32" height="32">
+  <object id="1112" name="Contract Vendor" type="Vendor" gid="6535" x="768" y="672" width="32" height="32">
    <properties>
     <property name="items" value="Free Contract"/>
     <property name="prices" value="100"/>
@@ -2449,24 +2737,24 @@
   </object>
  </objectgroup>
  <objectgroup id="6" name="Loot" opacity="0.75">
-  <object id="1007" name="Arcane Flint" type="RecallCharm" gid="6809" x="768" y="416" width="32" height="32">
+  <object id="1007" name="Arcane Flint" type="RecallCharm" gid="6809" x="768" y="512" width="32" height="32">
    <properties>
     <property name="recallId" value="Return Point"/>
    </properties>
   </object>
-  <object id="1067" name="Bomb" type="Bomb" gid="6495" x="32" y="32" width="32" height="32">
+  <object id="1067" name="Bomb" type="Bomb" gid="6495" x="32" y="128" width="32" height="32">
    <properties>
     <property name="range" value="0,1,2"/>
    </properties>
   </object>
-  <object id="1111" name="Free Contract" type="Contract" gid="6471" x="32" y="64" width="32" height="32">
+  <object id="1111" name="Free Contract" type="Contract" gid="6471" x="32" y="160" width="32" height="32">
    <properties>
     <property name="forSpecificUnit" type="bool" value="false"/>
    </properties>
   </object>
  </objectgroup>
  <objectgroup id="11" name="Summons" opacity="0.69">
-  <object id="946" name="Squeezy Jim" type="Creep" gid="21" x="0" y="32" width="32" height="32">
+  <object id="946" name="Squeezy Jim" type="Creep" gid="21" x="0" y="128" width="32" height="32">
    <properties>
     <property name="Class" value="Slime"/>
     <property name="routine_summon" type="bool" value="true"/>
@@ -2475,223 +2763,223 @@
   </object>
  </objectgroup>
  <objectgroup id="7" name="Items">
-  <object id="1055" name="Well-Crafted Blade" type="Weapon" gid="6823" x="480" y="512" width="32" height="32">
+  <object id="1055" name="Well-Crafted Blade" type="Weapon" gid="6823" x="480" y="608" width="32" height="32">
    <properties>
     <property name="atkValue" type="int" value="7"/>
    </properties>
   </object>
-  <object id="1056" name="Wand of Destruction" type="Weapon" gid="6825" x="192" y="384" width="32" height="32">
+  <object id="1056" name="Wand of Destruction" type="Weapon" gid="6825" x="192" y="480" width="32" height="32">
    <properties>
     <property name="atkRange" value="1,2"/>
     <property name="atkValue" type="int" value="6"/>
     <property name="luckModifier" type="int" value="2"/>
    </properties>
   </object>
-  <object id="1057" name="Magnet" type="Magnet" gid="6826" x="352" y="192" width="32" height="32"/>
-  <object id="1058" name="Magnet" type="Magnet" gid="6826" x="832" y="256" width="32" height="32"/>
-  <object id="1059" name="Longbow" type="Weapon" gid="6824" x="768" y="128" width="32" height="32">
+  <object id="1057" name="Magnet" type="Magnet" gid="6826" x="352" y="288" width="32" height="32"/>
+  <object id="1058" name="Magnet" type="Magnet" gid="6826" x="832" y="352" width="32" height="32"/>
+  <object id="1059" name="Longbow" type="Weapon" gid="6824" x="768" y="224" width="32" height="32">
    <properties>
     <property name="atkRange" value="2,3"/>
     <property name="atkValue" type="int" value="6"/>
    </properties>
   </object>
-  <object id="1060" name="Healthy Apple" type="HealthPotion" gid="6775" x="640" y="192" width="32" height="32">
+  <object id="1060" name="Healthy Apple" type="HealthPotion" gid="6775" x="640" y="288" width="32" height="32">
    <properties>
     <property name="hpHealed" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1061" name="Healthy Apple" type="HealthPotion" gid="6775" x="416" y="288" width="32" height="32">
+  <object id="1061" name="Healthy Apple" type="HealthPotion" gid="6775" x="416" y="384" width="32" height="32">
    <properties>
     <property name="hpHealed" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1062" name="Lucky Lemon" type="BuffItem" gid="6778" x="384" y="384" width="32" height="32">
+  <object id="1062" name="Lucky Lemon" type="BuffItem" gid="6778" x="384" y="480" width="32" height="32">
    <properties>
     <property name="stat" value="LCK"/>
    </properties>
   </object>
-  <object id="1063" name="Alert Berries" type="BuffItem" gid="6777" x="704" y="320" width="32" height="32">
+  <object id="1063" name="Alert Berries" type="BuffItem" gid="6777" x="704" y="416" width="32" height="32">
    <properties>
     <property name="modifier" type="int" value="2"/>
     <property name="stat" value="RET"/>
    </properties>
   </object>
-  <object id="1064" name="Swift Cheese" type="BuffItem" gid="6767" x="608" y="288" width="32" height="32">
+  <object id="1064" name="Swift Cheese" type="BuffItem" gid="6767" x="608" y="384" width="32" height="32">
    <properties>
     <property name="stat" value="MV"/>
    </properties>
   </object>
-  <object id="1065" name="Mighty Meat" type="BuffItem" gid="6792" x="32" y="384" width="32" height="32"/>
-  <object id="1068" name="Healthy Apple" type="HealthPotion" gid="6775" x="544" y="480" width="32" height="32">
+  <object id="1065" name="Mighty Meat" type="BuffItem" gid="6792" x="32" y="480" width="32" height="32"/>
+  <object id="1068" name="Healthy Apple" type="HealthPotion" gid="6775" x="544" y="576" width="32" height="32">
    <properties>
     <property name="hpHealed" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1069" name="Swift Cheese" type="BuffItem" gid="6767" x="320" y="480" width="32" height="32">
+  <object id="1069" name="Swift Cheese" type="BuffItem" gid="6767" x="320" y="576" width="32" height="32">
    <properties>
     <property name="stat" value="MV"/>
    </properties>
   </object>
-  <object id="1070" name="Emerald" type="Currency" gid="6784" x="448" y="192" width="32" height="32">
+  <object id="1070" name="Emerald" type="Currency" gid="6784" x="448" y="288" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1071" name="Sapphire" type="Currency" gid="6785" x="736" y="384" width="32" height="32">
+  <object id="1071" name="Sapphire" type="Currency" gid="6785" x="736" y="480" width="32" height="32">
    <properties>
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1072" name="Ruby" type="Currency" gid="6783" x="96" y="352" width="32" height="32">
+  <object id="1072" name="Ruby" type="Currency" gid="6783" x="96" y="448" width="32" height="32">
    <properties>
     <property name="value" type="int" value="30"/>
    </properties>
   </object>
-  <object id="1073" name="Ruby" type="Currency" gid="6783" x="864" y="256" width="32" height="32">
+  <object id="1073" name="Ruby" type="Currency" gid="6783" x="864" y="352" width="32" height="32">
    <properties>
     <property name="value" type="int" value="30"/>
    </properties>
   </object>
-  <object id="1074" name="Sapphire" type="Currency" gid="6785" x="576" y="544" width="32" height="32">
+  <object id="1074" name="Sapphire" type="Currency" gid="6785" x="576" y="640" width="32" height="32">
    <properties>
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1075" name="Emerald" type="Currency" gid="6784" x="640" y="384" width="32" height="32">
+  <object id="1075" name="Emerald" type="Currency" gid="6784" x="640" y="480" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1076" name="Emerald" type="Currency" gid="6784" x="384" y="448" width="32" height="32">
+  <object id="1076" name="Emerald" type="Currency" gid="6784" x="384" y="544" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1077" name="Emerald" type="Currency" gid="6784" x="288" y="512" width="32" height="32">
+  <object id="1077" name="Emerald" type="Currency" gid="6784" x="288" y="608" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1078" name="Emerald" type="Currency" gid="6784" x="96" y="448" width="32" height="32">
+  <object id="1078" name="Emerald" type="Currency" gid="6784" x="96" y="544" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1079" name="Emerald" type="Currency" gid="6784" x="64" y="256" width="32" height="32">
+  <object id="1079" name="Emerald" type="Currency" gid="6784" x="64" y="352" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1080" name="Emerald" type="Currency" gid="6784" x="416" y="96" width="32" height="32">
+  <object id="1080" name="Emerald" type="Currency" gid="6784" x="416" y="192" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1081" name="Emerald" type="Currency" gid="6784" x="512" y="128" width="32" height="32">
+  <object id="1081" name="Emerald" type="Currency" gid="6784" x="512" y="224" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1082" name="Emerald" type="Currency" gid="6784" x="704" y="96" width="32" height="32">
+  <object id="1082" name="Emerald" type="Currency" gid="6784" x="704" y="192" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1083" name="Emerald" type="Currency" gid="6784" x="896" y="96" width="32" height="32">
+  <object id="1083" name="Emerald" type="Currency" gid="6784" x="896" y="192" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1084" name="Emerald" type="Currency" gid="6784" x="800" y="288" width="32" height="32">
+  <object id="1084" name="Emerald" type="Currency" gid="6784" x="800" y="384" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1085" name="Emerald" type="Currency" gid="6784" x="736" y="544" width="32" height="32">
+  <object id="1085" name="Emerald" type="Currency" gid="6784" x="736" y="640" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1086" name="Sapphire" type="Currency" gid="6785" x="480" y="448" width="32" height="32">
+  <object id="1086" name="Sapphire" type="Currency" gid="6785" x="480" y="544" width="32" height="32">
    <properties>
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1087" name="Sapphire" type="Currency" gid="6785" x="320" y="544" width="32" height="32">
+  <object id="1087" name="Sapphire" type="Currency" gid="6785" x="320" y="640" width="32" height="32">
    <properties>
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1088" name="Sapphire" type="Currency" gid="6785" x="64" y="416" width="32" height="32">
+  <object id="1088" name="Sapphire" type="Currency" gid="6785" x="64" y="512" width="32" height="32">
    <properties>
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1089" name="Sapphire" type="Currency" gid="6785" x="352" y="256" width="32" height="32">
+  <object id="1089" name="Sapphire" type="Currency" gid="6785" x="352" y="352" width="32" height="32">
    <properties>
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1090" name="Sapphire" type="Currency" gid="6785" x="352" y="320" width="32" height="32">
+  <object id="1090" name="Sapphire" type="Currency" gid="6785" x="352" y="416" width="32" height="32">
    <properties>
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1091" name="Sapphire" type="Currency" gid="6785" x="224" y="288" width="32" height="32">
+  <object id="1091" name="Sapphire" type="Currency" gid="6785" x="224" y="384" width="32" height="32">
    <properties>
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1092" name="Emerald" type="Currency" gid="6784" x="896" y="384" width="32" height="32">
+  <object id="1092" name="Emerald" type="Currency" gid="6784" x="896" y="480" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1093" name="Sapphire" type="Currency" gid="6785" x="896" y="160" width="32" height="32">
+  <object id="1093" name="Sapphire" type="Currency" gid="6785" x="896" y="256" width="32" height="32">
    <properties>
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1094" name="Sapphire" type="Currency" gid="6785" x="832" y="96" width="32" height="32">
+  <object id="1094" name="Sapphire" type="Currency" gid="6785" x="832" y="192" width="32" height="32">
    <properties>
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1095" name="Sapphire" type="Currency" gid="6785" x="576" y="96" width="32" height="32">
+  <object id="1095" name="Sapphire" type="Currency" gid="6785" x="576" y="192" width="32" height="32">
    <properties>
     <property name="value" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1096" name="Emerald" type="Currency" gid="6784" x="576" y="224" width="32" height="32">
+  <object id="1096" name="Emerald" type="Currency" gid="6784" x="576" y="320" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1099" name="Emerald" type="Currency" gid="6784" x="768" y="544" width="32" height="32">
+  <object id="1099" name="Emerald" type="Currency" gid="6784" x="768" y="640" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1100" name="Emerald" type="Currency" gid="6784" x="160" y="224" width="32" height="32">
+  <object id="1100" name="Emerald" type="Currency" gid="6784" x="160" y="320" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="1101" name="Emerald" type="Currency" gid="6784" x="160" y="192" width="32" height="32">
+  <object id="1101" name="Emerald" type="Currency" gid="6784" x="160" y="288" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
  </objectgroup>
  <objectgroup id="8" name="Units">
-  <object id="943" name="Ko'Qi" type="Creep" gid="27" x="512" y="352" width="32" height="32">
+  <object id="943" name="Ko'Qi" type="Creep" gid="27" x="512" y="448" width="32" height="32">
    <properties>
     <property name="Class" value="Goblin"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
     <property name="routine_triggerHappy" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="912" name="Slim Jim" type="Creep" gid="21" x="224" y="384" width="32" height="32">
+  <object id="912" name="Slim Jim" type="Creep" gid="21" x="224" y="480" width="32" height="32">
    <properties>
     <property name="Class" value="Slime"/>
     <property name="routine_summon" type="bool" value="true"/>
@@ -2699,7 +2987,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="952" name="Glom Heckyell" type="Creep" gid="23" x="704" y="128" width="32" height="32">
+  <object id="952" name="Glom Heckyell" type="Creep" gid="23" x="704" y="224" width="32" height="32">
    <properties>
     <property name="Class" value="Orc"/>
     <property name="routine_glutton" type="bool" value="true"/>
@@ -2707,7 +2995,7 @@
     <property name="routine_prey" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="953" name="Nargok" type="Creep" gid="23" x="832" y="288" width="32" height="32">
+  <object id="953" name="Nargok" type="Creep" gid="23" x="832" y="384" width="32" height="32">
    <properties>
     <property name="Class" value="Orc"/>
     <property name="routine_glutton" type="bool" value="true"/>
@@ -2715,7 +3003,7 @@
     <property name="routine_prey" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="919" name="Wilson" type="Creep" gid="29" x="128" y="512" width="32" height="32">
+  <object id="919" name="Wilson" type="Creep" gid="29" x="128" y="608" width="32" height="32">
    <properties>
     <property name="Class" value="Rat"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
@@ -2723,19 +3011,19 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="918" name="Kesk" type="Creep" gid="28" x="608" y="128" width="32" height="32">
+  <object id="918" name="Kesk" type="Creep" gid="28" x="608" y="224" width="32" height="32">
    <properties>
     <property name="Class" value="Spider"/>
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="944" name="Kesk" type="Creep" gid="28" x="448" y="96" width="32" height="32">
+  <object id="944" name="Kesk" type="Creep" gid="28" x="448" y="192" width="32" height="32">
    <properties>
     <property name="Class" value="Spider"/>
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="917" name="Qi'Ko" type="Creep" gid="27" x="736" y="480" width="32" height="32">
+  <object id="917" name="Qi'Ko" type="Creep" gid="27" x="736" y="576" width="32" height="32">
    <properties>
     <property name="Class" value="Goblin"/>
     <property name="Independent" type="bool" value="true"/>
@@ -2745,13 +3033,13 @@
     <property name="routine_triggerHappy" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="920" name="Bruce" type="Creep" gid="30" x="672" y="288" width="32" height="32">
+  <object id="920" name="Bruce" type="Creep" gid="30" x="672" y="384" width="32" height="32">
    <properties>
     <property name="Class" value="Bat"/>
     <property name="routine_prey" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="914" name="Grog" type="Creep" gid="23" x="64" y="352" width="32" height="32">
+  <object id="914" name="Grog" type="Creep" gid="23" x="64" y="448" width="32" height="32">
    <properties>
     <property name="Class" value="Orc"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
@@ -2759,7 +3047,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1023" name="Wilson" type="Creep" gid="29" x="352" y="512" width="32" height="32">
+  <object id="1023" name="Wilson" type="Creep" gid="29" x="352" y="608" width="32" height="32">
    <properties>
     <property name="Class" value="Rat"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
@@ -2767,7 +3055,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1024" name="Wilson" type="Creep" gid="29" x="416" y="224" width="32" height="32">
+  <object id="1024" name="Wilson" type="Creep" gid="29" x="416" y="320" width="32" height="32">
    <properties>
     <property name="Class" value="Rat"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
@@ -2775,13 +3063,13 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1025" name="Kesk" type="Creep" gid="28" x="352" y="384" width="32" height="32">
+  <object id="1025" name="Kesk" type="Creep" gid="28" x="352" y="480" width="32" height="32">
    <properties>
     <property name="Class" value="Spider"/>
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1026" name="Bruce" type="Creep" gid="30" x="896" y="288" width="32" height="32">
+  <object id="1026" name="Bruce" type="Creep" gid="30" x="896" y="384" width="32" height="32">
    <properties>
     <property name="Class" value="Bat"/>
     <property name="routine_prey" type="bool" value="true"/>
@@ -2789,8 +3077,104 @@
   </object>
  </objectgroup>
  <objectgroup id="9" name="Disabled" opacity="0.24"/>
- <layer id="4" name="Overlay" width="32" height="20">
+ <layer id="15" name="Overlay" width="32" height="23">
   <data>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
    <tile/>
    <tile/>
    <tile/>

--- a/SolStandard/Content/TmxMaps/objecttypes.xml
+++ b/SolStandard/Content/TmxMaps/objecttypes.xml
@@ -23,6 +23,7 @@
   <property name="damage" type="int" default="10"/>
   <property name="itemPool" type="string"/>
   <property name="range" type="string" default="0,1,2"/>
+  <property name="turnsRemaining" type="int" default="2"/>
  </objecttype>
  <objecttype name="BreakableObstacle" color="#640000">
   <property name="HP" type="int" default="1"/>
@@ -90,8 +91,6 @@
  </objecttype>
  <objecttype name="Door" color="#625232">
   <property name="HP" type="int" default="10"/>
-  <property name="canMove" type="bool" default="false"/>
-  <property name="isBroken" type="bool" default="false"/>
   <property name="isLocked" type="bool" default="false"/>
   <property name="isOpen" type="bool" default="false"/>
   <property name="range" type="string" default="1"/>

--- a/SolStandard/Entity/General/Bank.cs
+++ b/SolStandard/Entity/General/Bank.cs
@@ -26,8 +26,7 @@ namespace SolStandard.Entity.General
         {
             CanMove = canMove;
             InteractRange = interactRange;
-            RedMoney = 0;
-            BlueMoney = 0;
+            ResetBank();
         }
 
         public List<UnitAction> TileActions()
@@ -102,6 +101,12 @@ namespace SolStandard.Entity.General
                 default:
                     throw new ArgumentOutOfRangeException("team", team, null);
             }
+        }
+
+        public static void ResetBank()
+        {
+            RedMoney = 0;
+            BlueMoney = 0;
         }
 
 

--- a/SolStandard/Entity/General/Door.cs
+++ b/SolStandard/Entity/General/Door.cs
@@ -23,13 +23,13 @@ namespace SolStandard.Entity.General
         private static readonly Color InactiveColor = new Color(0, 0, 0, 50);
 
         public Door(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, bool isLocked, bool isOpen, int[] range, int hp, bool canMove) :
-            base(name, type, sprite, mapCoordinates, tiledProperties, hp, canMove, false, 0)
+            Dictionary<string, string> tiledProperties, bool isLocked, bool isOpen, int[] range, int hp) :
+            base(name, type, sprite, mapCoordinates, tiledProperties, hp, isOpen, false, 0)
         {
             IsLocked = isLocked;
-            IsOpen = isOpen;
             InteractRange = range;
-            CanMove = canMove;
+            IsOpen = isOpen;
+            ElementColor = (IsOpen) ? InactiveColor : Color.White;
         }
 
         public override IRenderable TerrainInfo

--- a/SolStandard/Entity/Unit/Actions/DeployBombAction.cs
+++ b/SolStandard/Entity/Unit/Actions/DeployBombAction.cs
@@ -14,10 +14,10 @@ namespace SolStandard.Entity.Unit.Actions
     {
         private readonly Bomb bombToDeploy;
 
-        public DeployBombAction(Bomb bombToDeploy) : base(
+        public DeployBombAction(Bomb bombToDeploy, int fuseTurns) : base(
             icon: bombToDeploy.RenderSprite.Clone(),
             name: "Set Bomb",
-            description: "Place a bomb on an unoccupied tile. Will detonate at the beginning of the next round." +
+            description: "Place a bomb on an unoccupied tile. Will detonate after [" + fuseTurns + "] rounds." +
                          Environment.NewLine +
                          "Will detonate in a [" + string.Join(",", bombToDeploy.Range) + "] tile range." +
                          Environment.NewLine +

--- a/SolStandard/Entity/Unit/GameUnit.cs
+++ b/SolStandard/Entity/Unit/GameUnit.cs
@@ -230,7 +230,7 @@ namespace SolStandard.Entity.Unit
 
                     for (int i = 0; i < Inventory.Count; i++)
                     {
-                        content[i + offset, 0] = Inventory[i].Icon;
+                        content[i + offset, 0] = Inventory[i].Icon.Clone();
                         content[i + offset, 1] = new RenderText(AssetManager.WindowFont, Inventory[i].Name);
                     }
 

--- a/SolStandard/Map/TmxMapParser.cs
+++ b/SolStandard/Map/TmxMapParser.cs
@@ -332,8 +332,7 @@ namespace SolStandard.Map
                                             Convert.ToBoolean(currentProperties["isOpen"]),
                                             currentProperties["range"]
                                                 .Split(',').Select(n => Convert.ToInt32(n)).ToArray(),
-                                            Convert.ToInt32(currentProperties["HP"]),
-                                            Convert.ToBoolean(currentProperties["canMove"])
+                                            Convert.ToInt32(currentProperties["HP"])
                                         );
                                         break;
                                     case EntityTypes.Movable:
@@ -658,6 +657,7 @@ namespace SolStandard.Map
                                             currentProperties["range"].Split(',').Select(n => Convert.ToInt32(n))
                                                 .ToArray(),
                                             Convert.ToInt32(currentProperties["damage"]),
+                                            Convert.ToInt32(currentProperties["turnsRemaining"]),
                                             currentProperties["itemPool"],
                                             currentProperties
                                         );

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -336,6 +336,7 @@
     <Compile Include="Utility\Buttons\Network\NetworkController.cs" />
     <Compile Include="Utility\Events\AdditionalActionEvent.cs" />
     <Compile Include="Utility\Events\AI\CreepTriggerTileEvent.cs" />
+    <Compile Include="Utility\Events\AI\SpawnCreepEvent.cs" />
     <Compile Include="Utility\Events\BankDepositEvent.cs" />
     <Compile Include="Utility\Events\BankWithdrawEvent.cs" />
     <Compile Include="Utility\Events\CameraCursorPositionEvent.cs" />
@@ -369,7 +370,6 @@
     <Compile Include="Utility\Events\Network\SelectActionMenuOptionEvent.cs" />
     <Compile Include="Utility\Events\Network\SelectMapEvent.cs" />
     <Compile Include="Utility\Events\Network\SelectUnitEvent.cs" />
-    <Compile Include="Utility\Events\Network\SpawnCreepEvent.cs" />
     <Compile Include="Utility\Events\Network\SpawnUnitEvent.cs" />
     <Compile Include="Utility\Events\Network\ToggleCombatMenuEvent.cs" />
     <Compile Include="Utility\Events\PlaySoundEffectEvent.cs" />

--- a/SolStandard/Utility/Events/AI/SpawnCreepEvent.cs
+++ b/SolStandard/Utility/Events/AI/SpawnCreepEvent.cs
@@ -1,30 +1,27 @@
-using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using SolStandard.Entity.Unit;
 using SolStandard.Entity.Unit.Actions.Creeps;
 
-namespace SolStandard.Utility.Events.Network
+namespace SolStandard.Utility.Events.AI
 {
-    [Serializable]
-    public class SpawnCreepEvent : NetworkEvent
+    public class SpawnCreepEvent : IEvent
     {
         private readonly Role unitRole;
         private readonly Dictionary<string, string> entityProperties;
-        private readonly float x;
-        private readonly float y;
+        private readonly Vector2 coordinates;
+        public bool Complete { get; private set; }
 
         public SpawnCreepEvent(Role unitRole, Vector2 coordinates, Dictionary<string, string> entityProperties)
         {
             this.unitRole = unitRole;
             this.entityProperties = entityProperties;
-            x = coordinates.X;
-            y = coordinates.Y;
+            this.coordinates = coordinates;
         }
 
-        public override void Continue()
+        public void Continue()
         {
-            SummoningRoutine.PlaceCreepInTile(unitRole, new Vector2(x, y), entityProperties);
+            SummoningRoutine.PlaceCreepInTile(unitRole, coordinates, entityProperties);
             Complete = true;
         }
     }


### PR DESCRIPTION
## Bugfix Patch
### Quality of Life Updates
- Show Objectives during the Deployment Phase
### Minor Redesign
- Bombs 
    - Will have a configurable fuse so that you don't blow yourself up
    - Will have a fuse timer associated with the bomb
        - Visible on the map and in the item description
    - Bomb should not hurt units outside of range
### General Bugs
- Doors marked open in the map editor should be open as the map loads
- Money should no longer carry over from previous matches towards the Taxes win condition
    - Now resets the money in the bank before every game (should happen even if next map does not have a bank)
### Networking Bugs
- Creeps that spawn other creeps should no longer spawn duplicate creeps on the same tile.
- Network game desyncing related to duplicate summoning bug should be fixed as part of the fix above
### Map-Specific Bugs
King's Feast map updated to show what is in the chests (Gold vs Items) in the entity name