### PR TITLE
Sol 40 tech debt inventory rework

### DIFF
--- a/SolStandard/Containers/Contexts/ControlContext.cs
+++ b/SolStandard/Containers/Contexts/ControlContext.cs
@@ -503,12 +503,22 @@ namespace SolStandard.Containers.Contexts
                 GlobalEventQueue.QueueSingleEvent(new MoveActionMenuEvent(MenuCursorDirection.Down));
             }
 
-            if (controlMapper.Press(Input.CursorRight, PressType.Single))
+            if (controlMapper.Press(Input.CursorLeft, PressType.DelayedRepeat))
+            {
+                GlobalEventQueue.QueueSingleEvent(new MoveActionMenuEvent(MenuCursorDirection.Left));
+            }
+
+            if (controlMapper.Press(Input.CursorRight, PressType.DelayedRepeat))
+            {
+                GlobalEventQueue.QueueSingleEvent(new MoveActionMenuEvent(MenuCursorDirection.Right));
+            }
+
+            if (controlMapper.Press(Input.PreviewUnit, PressType.Single))
             {
                 GlobalEventQueue.QueueSingleEvent(new ToggleCombatMenuEvent());
             }
 
-            if (controlMapper.Press(Input.CursorLeft, PressType.Single))
+            if (controlMapper.Press(Input.PreviewItem, PressType.Single))
             {
                 GlobalEventQueue.QueueSingleEvent(new ToggleCombatMenuEvent());
             }

--- a/SolStandard/Containers/Contexts/ControlContext.cs
+++ b/SolStandard/Containers/Contexts/ControlContext.cs
@@ -208,12 +208,12 @@ namespace SolStandard.Containers.Contexts
                     GameContext.CurrentGameState));
             }
 
-            if (controlMapper.Press(Input.LeftBumper, PressType.DelayedRepeat))
+            if (controlMapper.Press(Input.TabLeft, PressType.DelayedRepeat))
             {
                 GlobalEventQueue.QueueSingleEvent(new DeploySelectPreviousUnitEvent());
             }
 
-            if (controlMapper.Press(Input.RightBumper, PressType.DelayedRepeat))
+            if (controlMapper.Press(Input.TabRight, PressType.DelayedRepeat))
             {
                 GlobalEventQueue.QueueSingleEvent(new DeploySelectNextUnitEvent());
             }
@@ -265,12 +265,12 @@ namespace SolStandard.Containers.Contexts
                 GlobalEventQueue.QueueSingleEvent(new SelectMapEvent());
             }
 
-            if (controlMapper.Press(Input.LeftBumper, PressType.Single))
+            if (controlMapper.Press(Input.TabLeft, PressType.Single))
             {
                 GlobalEventQueue.QueueSingleEvent(new ChangePlayerTeamsEvent(Team.Red));
             }
 
-            if (controlMapper.Press(Input.RightBumper, PressType.Single))
+            if (controlMapper.Press(Input.TabRight, PressType.Single))
             {
                 GlobalEventQueue.QueueSingleEvent(new ChangePlayerTeamsEvent(Team.Blue));
             }
@@ -341,12 +341,12 @@ namespace SolStandard.Containers.Contexts
 
         private static void CameraControl(ControlMapper controlMapper)
         {
-            if (controlMapper.Press(Input.LeftTrigger, PressType.DelayedRepeat))
+            if (controlMapper.Press(Input.ZoomOut, PressType.DelayedRepeat))
             {
                 GameContext.MapCamera.ZoomOut();
             }
 
-            if (controlMapper.Press(Input.RightTrigger, PressType.DelayedRepeat))
+            if (controlMapper.Press(Input.ZoomIn, PressType.DelayedRepeat))
             {
                 GameContext.MapCamera.ZoomIn();
             }
@@ -418,12 +418,12 @@ namespace SolStandard.Containers.Contexts
                     GameContext.CurrentGameState));
             }
 
-            if (controlMapper.Press(Input.LeftBumper, PressType.DelayedRepeat))
+            if (controlMapper.Press(Input.TabLeft, PressType.DelayedRepeat))
             {
                 GlobalEventQueue.QueueSingleEvent(new ResetCursorToPreviousUnitEvent());
             }
 
-            if (controlMapper.Press(Input.RightBumper, PressType.DelayedRepeat))
+            if (controlMapper.Press(Input.TabRight, PressType.DelayedRepeat))
             {
                 GlobalEventQueue.QueueSingleEvent(new ResetCursorToNextUnitEvent());
             }
@@ -533,12 +533,12 @@ namespace SolStandard.Containers.Contexts
                 GlobalEventQueue.QueueSingleEvent(new CancelActionMenuEvent());
             }
 
-            if (controlMapper.Press(Input.LeftBumper, PressType.DelayedRepeat))
+            if (controlMapper.Press(Input.TabLeft, PressType.DelayedRepeat))
             {
                 GlobalEventQueue.QueueSingleEvent(new DecrementCurrentAdjustableActionEvent(1));
             }
 
-            if (controlMapper.Press(Input.RightBumper, PressType.DelayedRepeat))
+            if (controlMapper.Press(Input.TabRight, PressType.DelayedRepeat))
             {
                 GlobalEventQueue.QueueSingleEvent(new IncrementCurrentAdjustableActionEvent(1));
             }

--- a/SolStandard/Containers/Contexts/GameMapContext.cs
+++ b/SolStandard/Containers/Contexts/GameMapContext.cs
@@ -651,7 +651,7 @@ namespace SolStandard.Containers.Contexts
             GameMapView.CloseAdHocDraftMenu();
         }
 
-        public void ToggleCombatMenu()
+        public void ToggleActionInventoryMenu()
         {
             MapContainer.ClearDynamicAndPreviewGrids();
             GameMapView.ToggleCombatMenu();

--- a/SolStandard/Containers/Contexts/UnitContextualActionMenuContext.cs
+++ b/SolStandard/Containers/Contexts/UnitContextualActionMenuContext.cs
@@ -35,7 +35,7 @@ namespace SolStandard.Containers.Contexts
             return options;
         }
 
-        public static IRenderable GetActionDescriptionAtIndex(VerticalMenu actionMenu)
+        public static IRenderable GetActionDescriptionAtIndex(IMenu actionMenu)
         {
             ActionOption action = actionMenu.CurrentOption as ActionOption;
             if (action != null)
@@ -46,13 +46,18 @@ namespace SolStandard.Containers.Contexts
             throw new SkillDescriptionNotFoundException();
         }
 
-        public static MenuOption[] GenerateInventoryMenuOptions(Color windowColour)
+        public static MenuOption[,] GenerateInventoryMenuOptions(Color windowColour)
         {
-            MenuOption[] options = new MenuOption[GameContext.ActiveUnit.InventoryActions.Count];
+            const int columns = 2;
+            MenuOption[,] options = new MenuOption[GameContext.ActiveUnit.Inventory.Count + 1, columns];
 
-            for (int i = 0; i < GameContext.ActiveUnit.InventoryActions.Count; i++)
+            options[0, 0] = new ActionOption(windowColour, new DropGiveGoldAction());
+            options[0, 1] = new ActionOption(windowColour, new Wait());
+
+            for (int i = 0; i < GameContext.ActiveUnit.Inventory.Count; i++)
             {
-                options[i] = new ActionOption(windowColour, GameContext.ActiveUnit.InventoryActions[i]);
+                options[i + 1, 0] = new ActionOption(windowColour, GameContext.ActiveUnit.Inventory[i].UseAction());
+                options[i + 1, 1] = new ActionOption(windowColour, GameContext.ActiveUnit.Inventory[i].DropAction());
             }
 
             return options;
@@ -65,11 +70,11 @@ namespace SolStandard.Containers.Contexts
 
             List<MapSlice> mapSlicesInRange = new List<MapSlice>();
             List<MapDistanceTile> distanceTiles = new List<MapDistanceTile>();
-            
+
             foreach (MapElement mapElement in MapContainer.GameGrid[(int) Layer.Dynamic])
             {
                 if (mapElement == null) continue;
-                
+
                 distanceTiles.Add(mapElement as MapDistanceTile);
                 mapSlicesInRange.Add(MapContainer.GetMapSliceAtCoordinates(mapElement.MapCoordinates));
             }

--- a/SolStandard/Containers/View/DeploymentView.cs
+++ b/SolStandard/Containers/View/DeploymentView.cs
@@ -104,9 +104,9 @@ namespace SolStandard.Containers.View
                 },
                 {
                     new RenderText(windowFont, "Press "),
-                    InputIconProvider.GetInputIcon(Input.LeftBumper, new Vector2(windowFont.MeasureString("A").Y)),
+                    InputIconProvider.GetInputIcon(Input.TabLeft, new Vector2(windowFont.MeasureString("A").Y)),
                     new RenderText(windowFont, " or "),
-                    InputIconProvider.GetInputIcon(Input.RightBumper, new Vector2(windowFont.MeasureString("A").Y)),
+                    InputIconProvider.GetInputIcon(Input.TabRight, new Vector2(windowFont.MeasureString("A").Y)),
                     new RenderText(windowFont, " to cycle between units.")
                 }
             };

--- a/SolStandard/Containers/View/GameMapView.cs
+++ b/SolStandard/Containers/View/GameMapView.cs
@@ -59,7 +59,7 @@ namespace SolStandard.Containers.View
         private VerticalMenu ActionMenu { get; set; }
         private Window ActionMenuDescriptionWindow { get; set; }
 
-        private VerticalMenu InventoryMenu { get; set; }
+        private TwoDimensionalMenu InventoryMenu { get; set; }
         private Window InventoryMenuDescriptionWindow { get; set; }
 
         private Window MenuDescriptionWindow { get; set; }
@@ -96,7 +96,7 @@ namespace SolStandard.Containers.View
             }
         }
 
-        public VerticalMenu CurrentMenu
+        public IMenu CurrentMenu
         {
             get
             {
@@ -247,12 +247,12 @@ namespace SolStandard.Containers.View
                 case MenuType.ActionMenu:
                     menuName = "Unit Actions";
                     windowText = new RenderText(AssetManager.HeaderFont, menuName);
-                    buttonIcon = InputIconProvider.GetInputIcon(Input.CursorRight, new Vector2(windowText.Height));
+                    buttonIcon = InputIconProvider.GetInputIcon(Input.PreviewItem, new Vector2(windowText.Height));
                     break;
                 case MenuType.InventoryMenu:
                     menuName = "Inventory";
                     windowText = new RenderText(AssetManager.HeaderFont, menuName);
-                    buttonIcon = InputIconProvider.GetInputIcon(Input.CursorLeft, new Vector2(windowText.Height));
+                    buttonIcon = InputIconProvider.GetInputIcon(Input.PreviewUnit, new Vector2(windowText.Height));
                     break;
                 default:
                     throw new ArgumentOutOfRangeException("menuType", menuType, null);
@@ -288,12 +288,13 @@ namespace SolStandard.Containers.View
 
         private void GenerateInventoryMenu(Color windowColor)
         {
-            MenuOption[] options = UnitContextualActionMenuContext.GenerateInventoryMenuOptions(windowColor);
+            MenuOption[,] options = UnitContextualActionMenuContext.GenerateInventoryMenuOptions(windowColor);
 
             IRenderable cursorSprite = new SpriteAtlas(AssetManager.MenuCursorTexture,
                 new Vector2(AssetManager.MenuCursorTexture.Width, AssetManager.MenuCursorTexture.Height));
 
-            InventoryMenu = new VerticalMenu(options, cursorSprite, windowColor);
+            InventoryMenu =
+                new TwoDimensionalMenu(options, cursorSprite, windowColor, TwoDimensionalMenu.CursorType.Pointer);
         }
 
         public void GenerateCurrentMenuDescription()
@@ -600,7 +601,7 @@ namespace SolStandard.Containers.View
         {
             //Center of screen
             return new Vector2(
-                GameDriver.ScreenSize.X / 3 - ActionMenu.Width,
+                GameDriver.ScreenSize.X / 3 - (float) ActionMenu.Width / 2,
                 (GameDriver.ScreenSize.Y / 2) - ((float) ActionMenu.Height / 2)
             );
         }
@@ -609,7 +610,7 @@ namespace SolStandard.Containers.View
         {
             //Center of screen
             return new Vector2(
-                GameDriver.ScreenSize.X / 3 - InventoryMenu.Width,
+                GameDriver.ScreenSize.X / 3 - (float) InventoryMenu.Width / 2,
                 (GameDriver.ScreenSize.Y / 2) - ((float) InventoryMenu.Height / 2)
             );
         }

--- a/SolStandard/Containers/View/MapSelectScreenView.cs
+++ b/SolStandard/Containers/View/MapSelectScreenView.cs
@@ -58,7 +58,7 @@ namespace SolStandard.Containers.View
             WindowContentGrid teamSelectContent = new WindowContentGrid(new [,]
                 {
                     {
-                        InputIconProvider.GetInputIcon(Input.LeftBumper, new Vector2(iconSize)),
+                        InputIconProvider.GetInputIcon(Input.TabLeft, new Vector2(iconSize)),
                         //SOL TEAM
                         new Window(new WindowContentGrid(new IRenderable[,]
                             {
@@ -103,7 +103,7 @@ namespace SolStandard.Containers.View
                                 },
                             }, 1, HorizontalAlignment.Centered), lunaWindowColor
                         ),
-                        InputIconProvider.GetInputIcon(Input.RightBumper, new Vector2(iconSize)),
+                        InputIconProvider.GetInputIcon(Input.TabRight, new Vector2(iconSize)),
                     }
                 }, 1, HorizontalAlignment.Centered
             );

--- a/SolStandard/Content/TmxMaps/Map_Select_04.tmx
+++ b/SolStandard/Content/TmxMaps/Map_Select_04.tmx
@@ -2039,7 +2039,7 @@
     <property name="draftUnits" type="bool" value="true"/>
     <property name="mapFileName" value="Draft_Escape_Prison.tmx"/>
     <property name="maxUnitsBlue" type="int" value="5"/>
-    <property name="maxUnitsRed" type="int" value="8"/>
+    <property name="maxUnitsRed" type="int" value="6"/>
     <property name="modeAssassinate" type="bool" value="false"/>
     <property name="modeEscape" type="bool" value="true"/>
     <property name="modeEscape.team" value="Blue"/>

--- a/SolStandard/Entity/GameEntity.cs
+++ b/SolStandard/Entity/GameEntity.cs
@@ -6,7 +6,7 @@ namespace SolStandard.Entity
     {
         private readonly string id;
         protected MapEntity MapEntity;
-        
+
         protected GameEntity(string id, MapEntity mapEntity)
         {
             this.id = id;

--- a/SolStandard/Entity/General/Artillery.cs
+++ b/SolStandard/Entity/General/Artillery.cs
@@ -18,9 +18,9 @@ namespace SolStandard.Entity.General
         private readonly WeaponStatistics weaponStatistics;
         private readonly Window statWindow;
 
-        public Artillery(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, bool canMove, int[] atkRange, int atkDamage) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+        public Artillery(string name, string type, IRenderable sprite, Vector2 mapCoordinates, bool canMove,
+            int[] atkRange, int atkDamage) :
+            base(name, type, sprite, mapCoordinates)
         {
             CanMove = canMove;
             AtkRange = atkRange;

--- a/SolStandard/Entity/General/Bank.cs
+++ b/SolStandard/Entity/General/Bank.cs
@@ -22,8 +22,8 @@ namespace SolStandard.Entity.General
         public static int BlueMoney { get; private set; }
 
         public Bank(string name, string type, IRenderable sprite, Vector2 mapCoordinates, bool canMove,
-            int[] interactRange, Dictionary<string, string> tiledProperties) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+            int[] interactRange) :
+            base(name, type, sprite, mapCoordinates)
         {
             CanMove = canMove;
             InteractRange = interactRange;

--- a/SolStandard/Entity/General/BreakableObstacle.cs
+++ b/SolStandard/Entity/General/BreakableObstacle.cs
@@ -18,9 +18,9 @@ namespace SolStandard.Entity.General
         private int gold;
         private readonly List<IItem> items;
 
-        public BreakableObstacle(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, int hp, bool canMove, bool isBroken, int gold,
-            IItem item = null) : base(name, type, sprite, mapCoordinates, tiledProperties)
+        public BreakableObstacle(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int hp,
+            bool canMove, bool isBroken, int gold, IItem item = null) :
+            base(name, type, sprite, mapCoordinates)
         {
             HP = hp;
             CanMove = canMove;

--- a/SolStandard/Entity/General/BuffTile.cs
+++ b/SolStandard/Entity/General/BuffTile.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using SolStandard.Containers.Contexts.Combat;
 using SolStandard.Entity.Unit;
 using SolStandard.HUD.Window;
@@ -15,9 +14,8 @@ namespace SolStandard.Entity.General
         public TerrainBonus TerrainBonus { get; private set; }
 
 
-        public BuffTile(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, int atkBonus, int retBonus, int blockBonus, int luckBonus,
-            bool canMove) : base(name, type, sprite, mapCoordinates, tiledProperties)
+        public BuffTile(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int atkBonus,
+            int retBonus, int blockBonus, int luckBonus, bool canMove) : base(name, type, sprite, mapCoordinates)
         {
             this.canMove = canMove;
             TerrainBonus = new TerrainBonus(atkBonus, retBonus, blockBonus, luckBonus);
@@ -52,18 +50,21 @@ namespace SolStandard.Entity.General
                                         },
                                         {
                                             UnitStatistics.GetSpriteAtlas(Stats.Retribution),
-                                            new RenderText(AssetManager.WindowFont, 
-                                                UnitStatistics.Abbreviation[Stats.Retribution] + ": +" + TerrainBonus.RetBonus),
+                                            new RenderText(AssetManager.WindowFont,
+                                                UnitStatistics.Abbreviation[Stats.Retribution] + ": +" +
+                                                TerrainBonus.RetBonus),
                                         },
                                         {
                                             UnitStatistics.GetSpriteAtlas(Stats.Armor),
-                                            new RenderText(AssetManager.WindowFont, 
-                                                UnitStatistics.Abbreviation[Stats.Armor] + ": +" + TerrainBonus.BlockBonus),
+                                            new RenderText(AssetManager.WindowFont,
+                                                UnitStatistics.Abbreviation[Stats.Armor] + ": +" +
+                                                TerrainBonus.BlockBonus),
                                         },
                                         {
                                             UnitStatistics.GetSpriteAtlas(Stats.Luck),
-                                            new RenderText(AssetManager.WindowFont, 
-                                                UnitStatistics.Abbreviation[Stats.Luck] + ": +" + TerrainBonus.LuckBonus),
+                                            new RenderText(AssetManager.WindowFont,
+                                                UnitStatistics.Abbreviation[Stats.Luck] + ": +" +
+                                                TerrainBonus.LuckBonus),
                                         }
                                     },
                                     0

--- a/SolStandard/Entity/General/Chest.cs
+++ b/SolStandard/Entity/General/Chest.cs
@@ -26,10 +26,10 @@ namespace SolStandard.Entity.General
 
         public List<IItem> Items { get; private set; }
 
-        public Chest(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, bool isLocked, bool isOpen, bool canMove, int[] range,
+        public Chest(string name, string type, IRenderable sprite, Vector2 mapCoordinates, bool isLocked, bool isOpen,
+            bool canMove, int[] range,
             int gold, IItem item = null) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+            base(name, type, sprite, mapCoordinates)
         {
             CanMove = canMove;
             IsLocked = isLocked;

--- a/SolStandard/Entity/General/Decoration.cs
+++ b/SolStandard/Entity/General/Decoration.cs
@@ -1,13 +1,12 @@
-﻿using System.Collections.Generic;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using SolStandard.Utility;
 
 namespace SolStandard.Entity.General
 {
     public class Decoration : TerrainEntity
     {
-        public Decoration(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties) : base(name, type, sprite, mapCoordinates, tiledProperties)
+        public Decoration(string name, string type, IRenderable sprite, Vector2 mapCoordinates) : base(name, type,
+            sprite, mapCoordinates)
         {
         }
     }

--- a/SolStandard/Entity/General/DeployTile.cs
+++ b/SolStandard/Entity/General/DeployTile.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using SolStandard.Entity.Unit;
 using SolStandard.Utility;
@@ -10,9 +9,8 @@ namespace SolStandard.Entity.General
         public Team DeployTeam { get; private set; }
         public bool Occupied { get; set; }
 
-        public DeployTile(string name, string type, IRenderable sprite, Vector2 mapCoordinates, Team deployTeam,
-            Dictionary<string, string> tiledProperties)
-            : base(name, type, sprite, mapCoordinates, tiledProperties)
+        public DeployTile(string name, string type, IRenderable sprite, Vector2 mapCoordinates, Team deployTeam)
+            : base(name, type, sprite, mapCoordinates)
         {
             DeployTeam = deployTeam;
             Occupied = false;

--- a/SolStandard/Entity/General/Door.cs
+++ b/SolStandard/Entity/General/Door.cs
@@ -22,9 +22,9 @@ namespace SolStandard.Entity.General
         public int[] InteractRange { get; private set; }
         private static readonly Color InactiveColor = new Color(0, 0, 0, 50);
 
-        public Door(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, bool isLocked, bool isOpen, int[] range, int hp) :
-            base(name, type, sprite, mapCoordinates, tiledProperties, hp, isOpen, false, 0)
+        public Door(string name, string type, IRenderable sprite, Vector2 mapCoordinates, bool isLocked, bool isOpen,
+            int[] range, int hp) :
+            base(name, type, sprite, mapCoordinates, hp, isOpen, false, 0)
         {
             IsLocked = isLocked;
             InteractRange = range;

--- a/SolStandard/Entity/General/Drawbridge.cs
+++ b/SolStandard/Entity/General/Drawbridge.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using SolStandard.Containers;
 using SolStandard.Containers.Contexts;
 using SolStandard.Entity.Unit;
@@ -16,9 +15,8 @@ namespace SolStandard.Entity.General
         public bool IsLocked { get; private set; }
         private static readonly Color InactiveColor = new Color(180, 180, 180, 100);
 
-        public Drawbridge(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, bool isOpen) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+        public Drawbridge(string name, string type, IRenderable sprite, Vector2 mapCoordinates, bool isOpen) :
+            base(name, type, sprite, mapCoordinates)
         {
             ElementColor = InactiveColor;
             IsOpen = isOpen;

--- a/SolStandard/Entity/General/EscapeEntity.cs
+++ b/SolStandard/Entity/General/EscapeEntity.cs
@@ -14,7 +14,7 @@ namespace SolStandard.Entity.General
 
         public EscapeEntity(string name, string type, IRenderable sprite, Vector2 mapCoordinates, bool useableByBlue,
             bool useableByRed)
-            : base(name, type, sprite, mapCoordinates, new Dictionary<string, string>())
+            : base(name, type, sprite, mapCoordinates)
         {
             UseableByBlue = useableByBlue;
             UseableByRed = useableByRed;

--- a/SolStandard/Entity/General/Item/Barricade.cs
+++ b/SolStandard/Entity/General/Item/Barricade.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using SolStandard.Entity.Unit.Actions;
 using SolStandard.Entity.Unit.Actions.Item;
@@ -10,9 +9,10 @@ namespace SolStandard.Entity.General.Item
     public class Barricade : BreakableObstacle, IItem
     {
         public string ItemPool { get; private set; }
-        
-        public Barricade(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int hp, string itemPool) :
-            base(name, type, sprite, mapCoordinates, new Dictionary<string, string>(), hp, false, hp < 1, 0)
+
+        public Barricade(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int hp,
+            string itemPool) :
+            base(name, type, sprite, mapCoordinates, hp, false, hp < 1, 0)
         {
             ItemPool = itemPool;
         }

--- a/SolStandard/Entity/General/Item/Barricade.cs
+++ b/SolStandard/Entity/General/Item/Barricade.cs
@@ -1,7 +1,7 @@
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using SolStandard.Entity.Unit.Actions;
 using SolStandard.Entity.Unit.Actions.Item;
-using SolStandard.Entity.Unit.Actions.Terrain;
 using SolStandard.Utility;
 
 namespace SolStandard.Entity.General.Item

--- a/SolStandard/Entity/General/Item/BlinkItem.cs
+++ b/SolStandard/Entity/General/Item/BlinkItem.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using SolStandard.Entity.Unit;
 using SolStandard.Entity.Unit.Actions;
+using SolStandard.Entity.Unit.Actions.Item;
 using SolStandard.Entity.Unit.Actions.Mage;
 using SolStandard.Entity.Unit.Actions.Terrain;
 using SolStandard.HUD.Window;

--- a/SolStandard/Entity/General/Item/BlinkItem.cs
+++ b/SolStandard/Entity/General/Item/BlinkItem.cs
@@ -20,7 +20,7 @@ namespace SolStandard.Entity.General.Item
 
         public BlinkItem(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int[] pickupRange,
             int[] blinkRange, int usesRemaining, string itemPool)
-            : base(name, type, sprite, mapCoordinates, new Dictionary<string, string>())
+            : base(name, type, sprite, mapCoordinates)
         {
             BlinkRange = blinkRange;
             InteractRange = pickupRange;
@@ -58,7 +58,8 @@ namespace SolStandard.Entity.General.Item
 
         public IItem Duplicate()
         {
-            return new BlinkItem(Name, Type, Sprite, MapCoordinates, InteractRange, BlinkRange, UsesRemaining, ItemPool);
+            return new BlinkItem(Name, Type, Sprite, MapCoordinates, InteractRange, BlinkRange, UsesRemaining,
+                ItemPool);
         }
 
         public override IRenderable TerrainInfo

--- a/SolStandard/Entity/General/Item/Bomb.cs
+++ b/SolStandard/Entity/General/Item/Bomb.cs
@@ -57,7 +57,7 @@ namespace SolStandard.Entity.General.Item
 
         public IItem Duplicate()
         {
-            return new Bomb(Name, Type, Sprite, MapCoordinates, Range, Damage, turnsRemaining, ItemPool);
+            return new Bomb(Name, Type, Sprite.Clone(), MapCoordinates, Range, Damage, turnsRemaining, ItemPool);
         }
 
         public bool Trigger(EffectTriggerTime triggerTime)

--- a/SolStandard/Entity/General/Item/Bomb.cs
+++ b/SolStandard/Entity/General/Item/Bomb.cs
@@ -7,7 +7,6 @@ using SolStandard.Containers.Contexts;
 using SolStandard.Entity.Unit;
 using SolStandard.Entity.Unit.Actions;
 using SolStandard.Entity.Unit.Actions.Item;
-using SolStandard.Entity.Unit.Actions.Terrain;
 using SolStandard.HUD.Window;
 using SolStandard.HUD.Window.Content;
 using SolStandard.Map;
@@ -176,7 +175,7 @@ namespace SolStandard.Entity.General.Item
             Draw(spriteBatch, ElementColor);
         }
 
-        public override void Draw(SpriteBatch spriteBatch, Color colorOverride)
+        protected override void Draw(SpriteBatch spriteBatch, Color colorOverride)
         {
             base.Draw(spriteBatch, colorOverride);
             if (Visible)

--- a/SolStandard/Entity/General/Item/Bomb.cs
+++ b/SolStandard/Entity/General/Item/Bomb.cs
@@ -28,8 +28,8 @@ namespace SolStandard.Entity.General.Item
         private int turnsRemaining;
 
         public Bomb(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int[] range, int damage,
-            int turnsRemaining, string itemPool, Dictionary<string, string> tiledProperties) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+            int turnsRemaining, string itemPool) :
+            base(name, type, sprite, mapCoordinates)
         {
             Range = range;
             Damage = damage;
@@ -57,8 +57,7 @@ namespace SolStandard.Entity.General.Item
 
         public IItem Duplicate()
         {
-            return new Bomb(Name, Type, Sprite, MapCoordinates, Range, Damage, turnsRemaining, ItemPool,
-                TiledProperties);
+            return new Bomb(Name, Type, Sprite, MapCoordinates, Range, Damage, turnsRemaining, ItemPool);
         }
 
         public bool Trigger(EffectTriggerTime triggerTime)

--- a/SolStandard/Entity/General/Item/BuffItem.cs
+++ b/SolStandard/Entity/General/Item/BuffItem.cs
@@ -31,7 +31,7 @@ namespace SolStandard.Entity.General.Item
 
         public BuffItem(string name, string type, IRenderable sprite, Vector2 mapCoordinates, string statistic,
             int statModifier, int buffDuration, int[] pickupRange, string itemPool)
-            : base(name, type, sprite, mapCoordinates, new Dictionary<string, string>())
+            : base(name, type, sprite, mapCoordinates)
         {
             InteractRange = pickupRange;
             ItemPool = itemPool;

--- a/SolStandard/Entity/General/Item/Contract.cs
+++ b/SolStandard/Entity/General/Item/Contract.cs
@@ -21,7 +21,7 @@ namespace SolStandard.Entity.General.Item
 
         public Contract(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int[] interactRange,
             string itemPool, bool forSpecificUnit, Role specificRole)
-            : base(name, type, sprite, mapCoordinates, new Dictionary<string, string>())
+            : base(name, type, sprite, mapCoordinates)
         {
             ItemPool = itemPool;
             InteractRange = interactRange;

--- a/SolStandard/Entity/General/Item/Contract.cs
+++ b/SolStandard/Entity/General/Item/Contract.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using SolStandard.Containers.Contexts;
 using SolStandard.Entity.Unit;
 using SolStandard.Entity.Unit.Actions;
+using SolStandard.Entity.Unit.Actions.Item;
 using SolStandard.Entity.Unit.Actions.Terrain;
 using SolStandard.HUD.Window;
 using SolStandard.HUD.Window.Content;

--- a/SolStandard/Entity/General/Item/Currency.cs
+++ b/SolStandard/Entity/General/Item/Currency.cs
@@ -18,9 +18,8 @@ namespace SolStandard.Entity.General.Item
         public int Value { get; private set; }
         public int[] InteractRange { get; private set; }
 
-        public Currency(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, int value, int[] range) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+        public Currency(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int value, int[] range) :
+            base(name, type, sprite, mapCoordinates)
         {
             Value = value;
             InteractRange = range;

--- a/SolStandard/Entity/General/Item/HealthPotion.cs
+++ b/SolStandard/Entity/General/Item/HealthPotion.cs
@@ -24,7 +24,7 @@ namespace SolStandard.Entity.General.Item
 
         public HealthPotion(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int[] pickupRange,
             int hpHealed, string itemPool)
-            : base(name, type, sprite, mapCoordinates, new Dictionary<string, string>())
+            : base(name, type, sprite, mapCoordinates)
         {
             InteractRange = pickupRange;
             HPHealed = hpHealed;

--- a/SolStandard/Entity/General/Item/Key.cs
+++ b/SolStandard/Entity/General/Item/Key.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using SolStandard.Entity.Unit;
 using SolStandard.Entity.Unit.Actions;
+using SolStandard.Entity.Unit.Actions.Item;
 using SolStandard.Entity.Unit.Actions.Terrain;
 using SolStandard.HUD.Window;
 using SolStandard.HUD.Window.Content;

--- a/SolStandard/Entity/General/Item/Key.cs
+++ b/SolStandard/Entity/General/Item/Key.cs
@@ -18,9 +18,8 @@ namespace SolStandard.Entity.General.Item
         public string ItemPool { get; private set; }
 
         public Key(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, string usedWith, int[] range, string itemPool,
-            bool isMasterKey) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+            string usedWith, int[] range, string itemPool, bool isMasterKey) :
+            base(name, type, sprite, mapCoordinates)
         {
             UsedWith = usedWith;
             InteractRange = range;
@@ -58,8 +57,7 @@ namespace SolStandard.Entity.General.Item
 
         public IItem Duplicate()
         {
-            return new Key(Name, Type, Sprite, MapCoordinates, TiledProperties, UsedWith, InteractRange, ItemPool,
-                IsMasterKey);
+            return new Key(Name, Type, Sprite, MapCoordinates, UsedWith, InteractRange, ItemPool, IsMasterKey);
         }
 
         public override IRenderable TerrainInfo

--- a/SolStandard/Entity/General/Item/LadderBridge.cs
+++ b/SolStandard/Entity/General/Item/LadderBridge.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using SolStandard.Entity.Unit.Actions;
 using SolStandard.Entity.Unit.Actions.Item;
@@ -13,8 +12,8 @@ namespace SolStandard.Entity.General.Item
         public string ItemPool { get; private set; }
 
         public LadderBridge(string name, string type, IRenderable sprite, Vector2 mapCoordinates, string itemPool,
-            bool canMove, Dictionary<string, string> tiledProperties) :
-            base(name, type, sprite, mapCoordinates, tiledProperties, canMove)
+            bool canMove) :
+            base(name, type, sprite, mapCoordinates, canMove)
         {
             Icon = sprite;
             ItemPool = itemPool;
@@ -37,7 +36,7 @@ namespace SolStandard.Entity.General.Item
 
         public IItem Duplicate()
         {
-            return new LadderBridge(Name, Type, Sprite, MapCoordinates, ItemPool, CanMove, TiledProperties);
+            return new LadderBridge(Name, Type, Sprite, MapCoordinates, ItemPool, CanMove);
         }
     }
 }

--- a/SolStandard/Entity/General/Item/LadderBridge.cs
+++ b/SolStandard/Entity/General/Item/LadderBridge.cs
@@ -1,7 +1,6 @@
 using Microsoft.Xna.Framework;
 using SolStandard.Entity.Unit.Actions;
 using SolStandard.Entity.Unit.Actions.Item;
-using SolStandard.Entity.Unit.Actions.Terrain;
 using SolStandard.Utility;
 
 namespace SolStandard.Entity.General.Item

--- a/SolStandard/Entity/General/Item/Magnet.cs
+++ b/SolStandard/Entity/General/Item/Magnet.cs
@@ -19,7 +19,7 @@ namespace SolStandard.Entity.General.Item
 
         public Magnet(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int[] pickupRange,
             int[] actionRange, int usesRemaining, string itemPool)
-            : base(name, type, sprite, mapCoordinates, new Dictionary<string, string>())
+            : base(name, type, sprite, mapCoordinates)
         {
             InteractRange = pickupRange;
             this.actionRange = actionRange;

--- a/SolStandard/Entity/General/Item/RecallCharm.cs
+++ b/SolStandard/Entity/General/Item/RecallCharm.cs
@@ -19,7 +19,7 @@ namespace SolStandard.Entity.General.Item
 
         public RecallCharm(string name, string type, IRenderable sprite, Vector2 mapCoordinates, string recallId,
             int[] pickupRange, string itemPool, int[] deployRange, int usesRemaining)
-            : base(name, type, sprite, mapCoordinates, new Dictionary<string, string>())
+            : base(name, type, sprite, mapCoordinates)
         {
             this.deployRange = deployRange;
             this.usesRemaining = usesRemaining;

--- a/SolStandard/Entity/General/Item/Relic.cs
+++ b/SolStandard/Entity/General/Item/Relic.cs
@@ -13,7 +13,7 @@ namespace SolStandard.Entity.General.Item
 
         public Relic(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int[] pickupRange,
             string itemPool) :
-            base(name, type, sprite, mapCoordinates, new Dictionary<string, string>())
+            base(name, type, sprite, mapCoordinates)
         {
             ItemPool = itemPool;
             InteractRange = pickupRange;

--- a/SolStandard/Entity/General/Item/Relic.cs
+++ b/SolStandard/Entity/General/Item/Relic.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using SolStandard.Entity.Unit.Actions;
+using SolStandard.Entity.Unit.Actions.Item;
 using SolStandard.Entity.Unit.Actions.Terrain;
 using SolStandard.Utility;
 
@@ -41,7 +42,7 @@ namespace SolStandard.Entity.General.Item
 
         public IItem Duplicate()
         {
-            return new Relic(Name, Type, Sprite, MapCoordinates, InteractRange, ItemPool);
+            return new Relic(Name, Type, Sprite.Clone(), MapCoordinates, InteractRange, ItemPool);
         }
 
 

--- a/SolStandard/Entity/General/Item/Spoils.cs
+++ b/SolStandard/Entity/General/Item/Spoils.cs
@@ -18,7 +18,7 @@ namespace SolStandard.Entity.General.Item
 
         public Spoils(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int gold,
             List<IItem> items) :
-            base(name, type, sprite, mapCoordinates, new Dictionary<string, string>())
+            base(name, type, sprite, mapCoordinates)
         {
             Gold = gold;
             Items = items;
@@ -61,7 +61,8 @@ namespace SolStandard.Entity.General.Item
                                 {
                                     {
                                         new SpriteAtlas(AssetManager.GoldIcon, new Vector2(GameDriver.CellSize)),
-                                        new RenderText(AssetManager.WindowFont,"Gold: " + Gold + Currency.CurrencyAbbreviation)
+                                        new RenderText(AssetManager.WindowFont,
+                                            "Gold: " + Gold + Currency.CurrencyAbbreviation)
                                     },
                                     {
                                         ItemDetails,

--- a/SolStandard/Entity/General/Item/Weapon.cs
+++ b/SolStandard/Entity/General/Item/Weapon.cs
@@ -20,7 +20,7 @@ namespace SolStandard.Entity.General.Item
 
         public Weapon(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int[] pickupRange,
             int atkValue, int luckModifier, int[] atkRange, int usesRemaining, string itemPool)
-            : base(name, type, sprite, mapCoordinates, new Dictionary<string, string>())
+            : base(name, type, sprite, mapCoordinates)
         {
             InteractRange = pickupRange;
             ItemPool = itemPool;

--- a/SolStandard/Entity/General/Item/Weapon.cs
+++ b/SolStandard/Entity/General/Item/Weapon.cs
@@ -59,7 +59,7 @@ namespace SolStandard.Entity.General.Item
 
         public UnitAction UseAction()
         {
-            return new WeaponAttack(Sprite, Name, WeaponStatistics);
+            return new WeaponAttack(Sprite, WeaponStatistics, this);
         }
 
         public UnitAction DropAction()

--- a/SolStandard/Entity/General/Item/WeaponStatistics.cs
+++ b/SolStandard/Entity/General/Item/WeaponStatistics.cs
@@ -68,7 +68,7 @@ namespace SolStandard.Entity.General.Item
                 },
                 {
                     StatusIconProvider.GetStatusIcon(StatusIcon.Durability, new Vector2(GameDriver.CellSize)),
-                    new RenderText(textFont,"Uses : [" + UsesRemaining + "]")
+                    new RenderText(textFont, "Uses : [" + UsesRemaining + "]")
                 },
             };
 

--- a/SolStandard/Entity/General/Movable.cs
+++ b/SolStandard/Entity/General/Movable.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using SolStandard.Entity.Unit;
 using SolStandard.HUD.Window.Content;
 using SolStandard.Utility;
@@ -9,13 +8,12 @@ namespace SolStandard.Entity.General
 {
     public class Movable : TerrainEntity
     {
-        public Movable(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, bool canMove) : base(name, type, sprite, mapCoordinates,
-            tiledProperties)
+        public Movable(string name, string type, IRenderable sprite, Vector2 mapCoordinates, bool canMove) :
+            base(name, type, sprite, mapCoordinates)
         {
             CanMove = canMove;
         }
-        
+
         public override IRenderable TerrainInfo
         {
             get

--- a/SolStandard/Entity/General/Portal.cs
+++ b/SolStandard/Entity/General/Portal.cs
@@ -15,9 +15,9 @@ namespace SolStandard.Entity.General
         private readonly string destinationId;
         public int[] InteractRange { get; private set; }
 
-        public Portal(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, bool canMove, string destinationId, int[] range) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+        public Portal(string name, string type, IRenderable sprite, Vector2 mapCoordinates, bool canMove,
+            string destinationId, int[] range) :
+            base(name, type, sprite, mapCoordinates)
         {
             this.canMove = canMove;
             this.destinationId = destinationId;

--- a/SolStandard/Entity/General/PressurePlate.cs
+++ b/SolStandard/Entity/General/PressurePlate.cs
@@ -23,9 +23,9 @@ namespace SolStandard.Entity.General
         private readonly bool triggerOnRelease;
         private const EffectTriggerTime TriggerTime = EffectTriggerTime.EndOfTurn;
 
-        public PressurePlate(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, string triggersId, bool triggerOnRelease) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+        public PressurePlate(string name, string type, IRenderable sprite, Vector2 mapCoordinates, string triggersId,
+            bool triggerOnRelease) :
+            base(name, type, sprite, mapCoordinates)
         {
             this.triggersId = triggersId;
             this.triggerOnRelease = triggerOnRelease;

--- a/SolStandard/Entity/General/PushBlock.cs
+++ b/SolStandard/Entity/General/PushBlock.cs
@@ -10,13 +10,13 @@ namespace SolStandard.Entity.General
     {
         public int[] InteractRange { get; private set; }
 
-        public PushBlock(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+        public PushBlock(string name, string type, IRenderable sprite, Vector2 mapCoordinates) :
+            base(name, type, sprite, mapCoordinates)
         {
             CanMove = false;
             InteractRange = new[] {1};
         }
+
         public List<UnitAction> TileActions()
         {
             return new List<UnitAction>

--- a/SolStandard/Entity/General/Railgun.cs
+++ b/SolStandard/Entity/General/Railgun.cs
@@ -18,14 +18,14 @@ namespace SolStandard.Entity.General
         private readonly WeaponStatistics weaponStatistics;
         private readonly Window statWindow;
 
-        public Railgun(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, bool canMove, int atkRange, int atkDamage) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+        public Railgun(string name, string type, IRenderable sprite, Vector2 mapCoordinates, bool canMove, int atkRange,
+            int atkDamage) :
+            base(name, type, sprite, mapCoordinates)
         {
             CanMove = canMove;
             AtkRange = atkRange;
             InteractRange = new[] {0};
-            weaponStatistics = new WeaponStatistics(atkDamage, -100, new []{AtkRange}, 100);
+            weaponStatistics = new WeaponStatistics(atkDamage, -100, new[] {AtkRange}, 100);
             statWindow = Weapon.BuildStatWindow(weaponStatistics);
         }
 

--- a/SolStandard/Entity/General/RecallPoint.cs
+++ b/SolStandard/Entity/General/RecallPoint.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using SolStandard.Utility;
 
@@ -9,7 +8,7 @@ namespace SolStandard.Entity.General
         private readonly string recallId;
 
         public RecallPoint(string recallId, IRenderable sprite, Vector2 mapCoordinates) :
-            base(recallId + " Point", "RecallPoint", sprite, mapCoordinates, new Dictionary<string, string>())
+            base(recallId + " Point", "RecallPoint", sprite, mapCoordinates)
         {
             this.recallId = recallId;
         }

--- a/SolStandard/Entity/General/RecoveryTile.cs
+++ b/SolStandard/Entity/General/RecoveryTile.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using SolStandard.Containers;
 using SolStandard.Containers.Contexts;
@@ -17,9 +16,8 @@ namespace SolStandard.Entity.General
         private readonly int hpPerTurn;
 
         public RecoveryTile(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int amrPerTurn,
-            int hpPerTurn,
-            Dictionary<string, string> tiledProperties) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+            int hpPerTurn) :
+            base(name, type, sprite, mapCoordinates)
         {
             this.amrPerTurn = amrPerTurn;
             this.hpPerTurn = hpPerTurn;
@@ -87,7 +85,7 @@ namespace SolStandard.Entity.General
         public bool WillTrigger(EffectTriggerTime triggerTime)
         {
             if (triggerTime != EffectTriggerTime.StartOfTurn) return false;
-            
+
             MapSlice recoverySlice = MapContainer.GetMapSliceAtCoordinates(MapCoordinates);
             GameUnit unitOnTile = UnitSelector.SelectUnit(recoverySlice.UnitEntity);
             return unitOnTile != null;

--- a/SolStandard/Entity/General/SeizeEntity.cs
+++ b/SolStandard/Entity/General/SeizeEntity.cs
@@ -17,9 +17,9 @@ namespace SolStandard.Entity.General
         public readonly bool CapturableByBlue;
         public readonly bool CapturableByRed;
 
-        public SeizeEntity(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, bool capturableByBlue, bool capturableByRed) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+        public SeizeEntity(string name, string type, IRenderable sprite, Vector2 mapCoordinates, bool capturableByBlue,
+            bool capturableByRed) :
+            base(name, type, sprite, mapCoordinates)
         {
             CapturableByBlue = capturableByBlue;
             CapturableByRed = capturableByRed;

--- a/SolStandard/Entity/General/SelectMapEntity.cs
+++ b/SolStandard/Entity/General/SelectMapEntity.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using SolStandard.Containers.Contexts.WinConditions;
 using SolStandard.Entity.Unit;
 using SolStandard.HUD.Window;
@@ -25,11 +24,10 @@ namespace SolStandard.Entity.General
 
         private static readonly Vector2 MaximumPreviewSize = new Vector2(300, 200);
 
-        public SelectMapEntity(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, MapInfo mapInfo, string mapSongName,
-            MapObjectives mapObjectives, bool draft, int maxBlueUnits, int maxRedUnits, int maxDuplicateUnits,
-            Team soloTeam, ITexture2D mapPreview) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+        public SelectMapEntity(string name, string type, IRenderable sprite, Vector2 mapCoordinates, MapInfo mapInfo,
+            string mapSongName, MapObjectives mapObjectives, bool draft, int maxBlueUnits, int maxRedUnits,
+            int maxDuplicateUnits, Team soloTeam, ITexture2D mapPreview) :
+            base(name, type, sprite, mapCoordinates)
         {
             MapInfo = mapInfo;
             MapSongName = mapSongName;

--- a/SolStandard/Entity/General/Switch.cs
+++ b/SolStandard/Entity/General/Switch.cs
@@ -23,9 +23,8 @@ namespace SolStandard.Entity.General
         private bool active;
         private static readonly Color ActiveColor = new Color(180, 180, 180);
 
-        public Switch(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties, string triggersId) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+        public Switch(string name, string type, IRenderable sprite, Vector2 mapCoordinates, string triggersId) :
+            base(name, type, sprite, mapCoordinates)
         {
             TriggersId = triggersId;
             InteractRange = new[] {1};

--- a/SolStandard/Entity/General/TerrainEntity.cs
+++ b/SolStandard/Entity/General/TerrainEntity.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using SolStandard.Entity.Unit;
 using SolStandard.HUD.Window;
 using SolStandard.HUD.Window.Content;
@@ -61,14 +60,14 @@ namespace SolStandard.Entity.General
 
         public bool CanMove { get; protected set; }
 
-        public TerrainEntity(string name, string type, IRenderable sprite, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties) : base(name, type, sprite, mapCoordinates, tiledProperties)
+        protected TerrainEntity(string name, string type, IRenderable sprite, Vector2 mapCoordinates) :
+            base(name, type, sprite, mapCoordinates)
         {
             CanMove = true;
 
             NameText = new RenderText(AssetManager.HeaderFont, Name);
             TypeText = new RenderText(AssetManager.WindowFont, "[" + Type + "]");
-            
+
             InfoHeader = new Window(
                 new WindowContentGrid(
                     new[,]

--- a/SolStandard/Entity/General/TrapEntity.cs
+++ b/SolStandard/Entity/General/TrapEntity.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using SolStandard.Containers;
 using SolStandard.Containers.Contexts;
@@ -30,7 +29,7 @@ namespace SolStandard.Entity.General
 
         public TrapEntity(string name, IRenderable sprite, Vector2 mapCoordinates, int damage, int triggersRemaining,
             bool limitedTriggers, bool enabled, bool willSnare = false, string itemPool = null) :
-            base(name, "Trap", sprite, mapCoordinates, new Dictionary<string, string>())
+            base(name, "Trap", sprite, mapCoordinates)
         {
             Damage = damage;
             TriggersRemaining = triggersRemaining;
@@ -96,7 +95,7 @@ namespace SolStandard.Entity.General
         public bool WillTrigger(EffectTriggerTime triggerTime)
         {
             if (triggerTime != EffectTriggerTime.StartOfTurn) return false;
-            
+
             MapSlice trapSlice = MapContainer.GetMapSliceAtCoordinates(MapCoordinates);
             GameUnit trapUnit = UnitSelector.SelectUnit(trapSlice.UnitEntity);
 

--- a/SolStandard/Entity/General/TrapEntity.cs
+++ b/SolStandard/Entity/General/TrapEntity.cs
@@ -4,6 +4,7 @@ using SolStandard.Containers;
 using SolStandard.Containers.Contexts;
 using SolStandard.Entity.Unit;
 using SolStandard.Entity.Unit.Actions;
+using SolStandard.Entity.Unit.Actions.Item;
 using SolStandard.Entity.Unit.Actions.Terrain;
 using SolStandard.Entity.Unit.Statuses;
 using SolStandard.HUD.Window;

--- a/SolStandard/Entity/General/Vendor.cs
+++ b/SolStandard/Entity/General/Vendor.cs
@@ -24,7 +24,7 @@ namespace SolStandard.Entity.General
         public Vendor(string name, string type, IRenderable sprite, Vector2 mapCoordinates, bool canMove,
             int[] interactRange, IReadOnlyList<IItem> items, IReadOnlyList<int> prices, int[] quantities,
             Dictionary<string, string> tiledProperties) :
-            base(name, type, sprite, mapCoordinates, tiledProperties)
+            base(name, type, sprite, mapCoordinates)
         {
             if (items.Count != prices.Count || items.Count != quantities.Length)
             {

--- a/SolStandard/Entity/IEffectTile.cs
+++ b/SolStandard/Entity/IEffectTile.cs
@@ -1,5 +1,4 @@
-﻿
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 
 namespace SolStandard.Entity
 {
@@ -8,7 +7,7 @@ namespace SolStandard.Entity
         StartOfTurn,
         EndOfTurn
     }
-    
+
     public interface IEffectTile
     {
         bool Trigger(EffectTriggerTime triggerTime);

--- a/SolStandard/Entity/Unit/Actions/Champion/Shove.cs
+++ b/SolStandard/Entity/Unit/Actions/Champion/Shove.cs
@@ -58,7 +58,7 @@ namespace SolStandard.Entity.Unit.Actions.Champion
             Vector2 oppositeCoordinates = DetermineOppositeTileOfUnit(actorCoordinates, targetCoordinates);
 
             return TargetIsUnitInRange(targetSlice, targetUnit) &&
-                   UnitMovingContext.CanEndMoveAtCoordinates(oppositeCoordinates) && 
+                   UnitMovingContext.CanEndMoveAtCoordinates(oppositeCoordinates) &&
                    targetUnit.IsMovable;
         }
     }

--- a/SolStandard/Entity/Unit/Actions/DropGiveGoldAction.cs
+++ b/SolStandard/Entity/Unit/Actions/DropGiveGoldAction.cs
@@ -34,10 +34,10 @@ namespace SolStandard.Entity.Unit.Actions
         {
             Vector2 iconSize = new Vector2(GameDriver.CellSize);
 
-            return new WindowContentGrid(new [,]
+            return new WindowContentGrid(new[,]
                 {
                     {
-                        new RenderText(AssetManager.WindowFont,"Drop"),
+                        new RenderText(AssetManager.WindowFont, "Drop"),
                         ObjectiveIconProvider.GetObjectiveIcon(VictoryConditions.Taxes, iconSize),
                         new RenderText(AssetManager.WindowFont,
                             Currency.CurrencyAbbreviation + " on an empty item tile or give it to an ally."),

--- a/SolStandard/Entity/Unit/Actions/DropGiveGoldAction.cs
+++ b/SolStandard/Entity/Unit/Actions/DropGiveGoldAction.cs
@@ -46,9 +46,9 @@ namespace SolStandard.Entity.Unit.Actions
                     },
                     {
                         new RenderText(AssetManager.WindowFont, "Adjust value to give with "),
-                        InputIconProvider.GetInputIcon(Input.LeftBumper, iconSize),
+                        InputIconProvider.GetInputIcon(Input.TabLeft, iconSize),
                         new RenderText(AssetManager.WindowFont, " and "),
-                        InputIconProvider.GetInputIcon(Input.RightBumper, iconSize),
+                        InputIconProvider.GetInputIcon(Input.TabRight, iconSize),
                         new RenderText(AssetManager.WindowFont, ""),
                     }
                 },

--- a/SolStandard/Entity/Unit/Actions/Item/ConsumeBuffItemAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Item/ConsumeBuffItemAction.cs
@@ -15,8 +15,8 @@ namespace SolStandard.Entity.Unit.Actions.Item
 
         public ConsumeBuffItemAction(IConsumable item, Stats statistic, int statModifier, int buffDuration,
             int[] range) : base(
-            icon: item.Icon,
-            name: "Consume: " + item.Name,
+            icon: item.Icon.Clone(),
+            name: "Consume",
             description: string.Format("Single use. Target modifies {0} by [{1}] for [{2}] turns.",
                 UnitStatistics.Abbreviation[statistic], statModifier, buffDuration),
             tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Action),

--- a/SolStandard/Entity/Unit/Actions/Item/ConsumeRecoveryItemAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Item/ConsumeRecoveryItemAction.cs
@@ -13,8 +13,8 @@ namespace SolStandard.Entity.Unit.Actions.Item
         private readonly HealthPotion potion;
 
         public ConsumeRecoveryItemAction(HealthPotion potion, int hpHealed, int[] range) : base(
-            icon: potion.Icon,
-            name: "Recover HP: " + potion.Name,
+            icon: potion.Icon.Clone(),
+            name: "Recover <" + hpHealed + "> HP",
             description: "Single use. Target recovers [" + hpHealed + "] HP.",
             tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Action),
             range: range,

--- a/SolStandard/Entity/Unit/Actions/Item/DeployBarricadeAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Item/DeployBarricadeAction.cs
@@ -14,7 +14,7 @@ namespace SolStandard.Entity.Unit.Actions.Item
         private readonly Barricade barricade;
 
         public DeployBarricadeAction(Barricade barricade) : base(
-            icon: barricade.RenderSprite,
+            icon: barricade.RenderSprite.Clone(),
             name: "Place Obstacle",
             description: "Place a breakable obstacle on an unoccupied tile.",
             tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Action),

--- a/SolStandard/Entity/Unit/Actions/Item/DeployLadderBridgeAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Item/DeployLadderBridgeAction.cs
@@ -15,7 +15,7 @@ namespace SolStandard.Entity.Unit.Actions.Item
         private readonly LadderBridge ladderBridge;
 
         public DeployLadderBridgeAction(LadderBridge ladderBridge) : base(
-            icon: ladderBridge.RenderSprite,
+            icon: ladderBridge.RenderSprite.Clone(),
             name: "Place Ladder/Bridge",
             description: "Place a ladder/bridge on an unoccupied immovable tile." + Environment.NewLine +
                          "Cannot be picked up once placed!",

--- a/SolStandard/Entity/Unit/Actions/Item/DropGiveItemAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Item/DropGiveItemAction.cs
@@ -1,21 +1,22 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using SolStandard.Containers.Contexts;
+using SolStandard.Entity.General;
 using SolStandard.Map.Elements;
 using SolStandard.Map.Elements.Cursor;
 using SolStandard.Utility;
 using SolStandard.Utility.Assets;
 using SolStandard.Utility.Events;
 
-namespace SolStandard.Entity.Unit.Actions.Terrain
+namespace SolStandard.Entity.Unit.Actions.Item
 {
-    public class TradeItemAction : UnitAction
+    public class DropGiveItemAction : UnitAction
     {
         private readonly IItem item;
 
-        public TradeItemAction(IItem item) : base(
+        public DropGiveItemAction(IItem item) : base(
             icon: item.Icon.Clone(),
-            name: "Give: " + item.Name,
-            description: "Give this item to an ally in range.",
+            name: "Drop/Give",
+            description: "Drop this item on an empty item tile or give it to an ally.",
             tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Action),
             range: new[] {0, 1},
             freeAction: false
@@ -26,13 +27,18 @@ namespace SolStandard.Entity.Unit.Actions.Terrain
 
         public override void ExecuteAction(MapSlice targetSlice)
         {
+            TerrainEntity itemTile = item as TerrainEntity;
             GameUnit actingUnit = GameContext.ActiveUnit;
             GameUnit targetUnit = UnitSelector.SelectUnit(targetSlice.UnitEntity);
 
-            if (CanGiveItemToAlly(targetUnit, actingUnit, targetSlice))
+            if (TradeItemAction.CanGiveItemToAlly(targetUnit, actingUnit, targetSlice))
+            {
+                new TradeItemAction(item).ExecuteAction(targetSlice);
+            }
+            else if (CanPlaceItemAtSlice(itemTile, targetSlice))
             {
                 Queue<IEvent> eventQueue = new Queue<IEvent>();
-                eventQueue.Enqueue(new TransferUnitItemEvent(actingUnit, targetUnit, item));
+                eventQueue.Enqueue(new DropItemEvent(itemTile, targetSlice.MapCoordinates));
                 eventQueue.Enqueue(new WaitFramesEvent(10));
                 eventQueue.Enqueue(new EndTurnEvent());
                 GlobalEventQueue.QueueEvents(eventQueue);
@@ -44,10 +50,10 @@ namespace SolStandard.Entity.Unit.Actions.Terrain
             }
         }
 
-        public static bool CanGiveItemToAlly(GameUnit targetUnit, GameUnit actingUnit, MapSlice targetSlice)
+        private static bool CanPlaceItemAtSlice(TerrainEntity itemTile, MapSlice targetSlice)
         {
-            return targetUnit != null && targetUnit.Team == actingUnit.Team && targetUnit != actingUnit &&
-                   targetSlice.DynamicEntity != null;
+            return targetSlice.ItemEntity == null && itemTile != null && targetSlice.DynamicEntity != null &&
+                   UnitMovingContext.CanEndMoveAtCoordinates(targetSlice.MapCoordinates);
         }
     }
 }

--- a/SolStandard/Entity/Unit/Actions/Item/MagneticPullAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Item/MagneticPullAction.cs
@@ -19,7 +19,7 @@ namespace SolStandard.Entity.Unit.Actions.Item
 
         public MagneticPullAction(Magnet magnet, IRenderable skillIcon, int[] skillRange) :
             base(
-                icon: skillIcon,
+                icon: skillIcon.Clone(),
                 name: "Pull Unit",
                 description: "Pull target unit towards you.",
                 tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Action),

--- a/SolStandard/Entity/Unit/Actions/Item/WeaponAttack.cs
+++ b/SolStandard/Entity/Unit/Actions/Item/WeaponAttack.cs
@@ -15,10 +15,11 @@ namespace SolStandard.Entity.Unit.Actions.Item
     public class WeaponAttack : UnitAction
     {
         private readonly WeaponStatistics stats;
+        private readonly Weapon sourceWeapon;
 
-        public WeaponAttack(IRenderable icon, string weaponName, WeaponStatistics stats) : base(
+        public WeaponAttack(IRenderable icon, WeaponStatistics stats, Weapon sourceWeapon) : base(
             icon: icon,
-            name: "Attack: " + weaponName,
+            name: "Attack",
             description: WeaponDescription(stats),
             tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Attack),
             range: null,
@@ -26,6 +27,7 @@ namespace SolStandard.Entity.Unit.Actions.Item
         )
         {
             this.stats = stats;
+            this.sourceWeapon = sourceWeapon;
         }
 
         private static WindowContentGrid WeaponDescription(WeaponStatistics stats)
@@ -92,7 +94,9 @@ namespace SolStandard.Entity.Unit.Actions.Item
             stats.DecrementRemainingUses();
             if (!stats.IsBroken) return;
 
-            GameContext.ActiveUnit.InventoryActions.Remove(this);
+            GameContext.ActiveUnit.RemoveItemFromInventory(sourceWeapon);
+            GameContext.GameMapContext.MapContainer.AddNewToastAtMapCursor("Weapon is broken!", 50);
+            AssetManager.CombatDeathSFX.Play();
 
             SpriteAtlas icon = Icon as SpriteAtlas;
             if (icon != null) icon.DefaultColor = GameUnit.DeadPortraitColor;

--- a/SolStandard/Entity/Unit/Actions/Item/WeaponAttack.cs
+++ b/SolStandard/Entity/Unit/Actions/Item/WeaponAttack.cs
@@ -19,7 +19,7 @@ namespace SolStandard.Entity.Unit.Actions.Item
         public WeaponAttack(IRenderable icon, string weaponName, WeaponStatistics stats) : base(
             icon: icon,
             name: "Attack: " + weaponName,
-            description:  WeaponDescription(stats),
+            description: WeaponDescription(stats),
             tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Attack),
             range: null,
             freeAction: false
@@ -33,7 +33,8 @@ namespace SolStandard.Entity.Unit.Actions.Item
             return new WindowContentGrid(new IRenderable[,]
                 {
                     {
-                        new RenderText(AssetManager.WindowFont, "Perform a basic attack against target based on your weapon's statistics."), 
+                        new RenderText(AssetManager.WindowFont,
+                            "Perform a basic attack against target based on your weapon's statistics."),
                     },
                     {
                         stats.GenerateStatGrid(AssetManager.WindowFont)

--- a/SolStandard/Entity/Unit/Actions/Lancer/Venom.cs
+++ b/SolStandard/Entity/Unit/Actions/Lancer/Venom.cs
@@ -34,7 +34,8 @@ namespace SolStandard.Entity.Unit.Actions.Lancer
 
             if (TargetIsAnEnemyInRange(targetSlice, targetUnit))
             {
-                GlobalEventQueue.QueueSingleEvent(new CastStatusEffectEvent(targetUnit, new RetributionStatDown(duration, retDebuffValue)));
+                GlobalEventQueue.QueueSingleEvent(new CastStatusEffectEvent(targetUnit,
+                    new RetributionStatDown(duration, retDebuffValue)));
                 GlobalEventQueue.QueueSingleEvent(new WaitFramesEvent(30));
                 GlobalEventQueue.QueueSingleEvent(new AdditionalActionEvent());
             }

--- a/SolStandard/Entity/Unit/Actions/LayTrap.cs
+++ b/SolStandard/Entity/Unit/Actions/LayTrap.cs
@@ -22,7 +22,7 @@ namespace SolStandard.Entity.Unit.Actions
         protected LayTrap(IRenderable skillIcon, IRenderable trapSprite, string title, int damage, int maxTriggers,
             string description = null, bool freeAction = false)
             : base(
-                icon: skillIcon,
+                icon: skillIcon.Clone(),
                 name: title,
                 description: description ?? ("Place a tile that will deal [" + damage +
                                              "] damage to enemies that start their turn on it." + Environment.NewLine +

--- a/SolStandard/Entity/Unit/Actions/Mage/Terraform.cs
+++ b/SolStandard/Entity/Unit/Actions/Mage/Terraform.cs
@@ -75,8 +75,7 @@ namespace SolStandard.Entity.Unit.Actions.Mage
 
         private BreakableObstacle GenerateObstacle(Vector2 mapCoordinates)
         {
-            return new BreakableObstacle("Rubble", "BreakableObstacle", Icon, mapCoordinates,
-                new Dictionary<string, string>(), 1, false, false, 0);
+            return new BreakableObstacle("Rubble", "BreakableObstacle", Icon, mapCoordinates, 1, false, false, 0);
         }
 
         private static bool TargetIsUnoccupiedTileInRange(MapSlice targetSlice)

--- a/SolStandard/Entity/Unit/Actions/Terrain/BankDeposit.cs
+++ b/SolStandard/Entity/Unit/Actions/Terrain/BankDeposit.cs
@@ -49,7 +49,7 @@ namespace SolStandard.Entity.Unit.Actions.Terrain
         {
             Vector2 iconSize = new Vector2(GameDriver.CellSize);
 
-            return new WindowContentGrid(new [,]
+            return new WindowContentGrid(new[,]
                 {
                     {
                         new RenderText(AssetManager.WindowFont, "Deposit"),

--- a/SolStandard/Entity/Unit/Actions/Terrain/BankDeposit.cs
+++ b/SolStandard/Entity/Unit/Actions/Terrain/BankDeposit.cs
@@ -63,9 +63,9 @@ namespace SolStandard.Entity.Unit.Actions.Terrain
                     },
                     {
                         new RenderText(AssetManager.WindowFont, "Adjust value to deposit with "),
-                        InputIconProvider.GetInputIcon(Input.LeftBumper, iconSize),
+                        InputIconProvider.GetInputIcon(Input.TabLeft, iconSize),
                         new RenderText(AssetManager.WindowFont, " and "),
-                        InputIconProvider.GetInputIcon(Input.RightBumper, iconSize),
+                        InputIconProvider.GetInputIcon(Input.TabRight, iconSize),
                         new RenderText(AssetManager.WindowFont, ""),
                     }
                 },

--- a/SolStandard/Entity/Unit/Actions/Terrain/BankWithdraw.cs
+++ b/SolStandard/Entity/Unit/Actions/Terrain/BankWithdraw.cs
@@ -48,7 +48,7 @@ namespace SolStandard.Entity.Unit.Actions.Terrain
         {
             Vector2 iconSize = new Vector2(GameDriver.CellSize);
 
-            return new WindowContentGrid(new [,]
+            return new WindowContentGrid(new[,]
                 {
                     {
                         new RenderText(AssetManager.WindowFont, "Withdraw"),

--- a/SolStandard/Entity/Unit/Actions/Terrain/BankWithdraw.cs
+++ b/SolStandard/Entity/Unit/Actions/Terrain/BankWithdraw.cs
@@ -59,9 +59,9 @@ namespace SolStandard.Entity.Unit.Actions.Terrain
                     },
                     {
                         new RenderText(AssetManager.WindowFont, "Adjust value to withdraw with "),
-                        InputIconProvider.GetInputIcon(Input.LeftBumper, iconSize),
+                        InputIconProvider.GetInputIcon(Input.TabLeft, iconSize),
                         new RenderText(AssetManager.WindowFont, " and "),
-                        InputIconProvider.GetInputIcon(Input.RightBumper, iconSize),
+                        InputIconProvider.GetInputIcon(Input.TabRight, iconSize),
                         new RenderText(AssetManager.WindowFont, ""),
                     }
                 },

--- a/SolStandard/Entity/Unit/Actions/Terrain/PushBlockAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Terrain/PushBlockAction.cs
@@ -33,7 +33,7 @@ namespace SolStandard.Entity.Unit.Actions.Terrain
         {
             MapContainer.GameGrid[(int) mapLayer][(int) blockCoordinates.X, (int) blockCoordinates.Y] =
                 new MapDistanceTile(TileSprite, blockCoordinates);
-            
+
             GameContext.GameMapContext.MapContainer.MapCursor.SnapCursorToCoordinates(blockCoordinates);
         }
 

--- a/SolStandard/Entity/Unit/Actions/Terrain/SeizeAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Terrain/SeizeAction.cs
@@ -53,7 +53,8 @@ namespace SolStandard.Entity.Unit.Actions.Terrain
                 }
                 else
                 {
-                    GameContext.GameMapContext.MapContainer.AddNewToastAtMapCursor("Cannot be seized by this team!", 50);
+                    GameContext.GameMapContext.MapContainer.AddNewToastAtMapCursor("Cannot be seized by this team!",
+                        50);
                     AssetManager.WarningSFX.Play();
                 }
             }

--- a/SolStandard/Entity/Unit/Actions/Terrain/UseDoorAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Terrain/UseDoorAction.cs
@@ -52,7 +52,7 @@ namespace SolStandard.Entity.Unit.Actions.Terrain
                     Queue<IEvent> eventQueue = new Queue<IEvent>();
                     eventQueue.Enqueue(new ToggleOpenEvent(door));
                     eventQueue.Enqueue(new WaitFramesEvent(10));
-                    
+
                     if (FreeAction)
                     {
                         eventQueue.Enqueue(new AdditionalActionEvent());

--- a/SolStandard/Entity/Unit/Actions/Terrain/VendorPurchase.cs
+++ b/SolStandard/Entity/Unit/Actions/Terrain/VendorPurchase.cs
@@ -21,7 +21,7 @@ namespace SolStandard.Entity.Unit.Actions.Terrain
 
         public VendorPurchase(IItem item, int price, Vendor vendor) : base(
             icon: item.Icon.Clone(),
-            name: "Purchase " + item.Name + ": " + price + Currency.CurrencyAbbreviation,
+            name: "Buy " + item.Name + ": " + price + Currency.CurrencyAbbreviation,
             description: new WindowContentGrid(new[,]
                 {
                     {

--- a/SolStandard/Entity/Unit/Actions/UnitAction.cs
+++ b/SolStandard/Entity/Unit/Actions/UnitAction.cs
@@ -19,7 +19,8 @@ namespace SolStandard.Entity.Unit.Actions
         public int[] Range { get; protected set; }
         public bool FreeAction { get; private set; }
 
-        protected UnitAction(IRenderable icon, string name, IRenderable description, SpriteAtlas tileSprite, int[] range, bool freeAction)
+        protected UnitAction(IRenderable icon, string name, IRenderable description, SpriteAtlas tileSprite,
+            int[] range, bool freeAction)
         {
             Icon = icon;
             Name = name;
@@ -30,9 +31,9 @@ namespace SolStandard.Entity.Unit.Actions
         }
 
         protected UnitAction(IRenderable icon, string name, string description, SpriteAtlas tileSprite,
-            int[] range, bool freeAction) : this (icon, name, DescriptionRenderText(description), tileSprite, range, freeAction)
+            int[] range, bool freeAction) : this(icon, name, DescriptionRenderText(description), tileSprite, range,
+            freeAction)
         {
-            
         }
 
         private static RenderText DescriptionRenderText(string description)

--- a/SolStandard/Entity/Unit/CreepEntity.cs
+++ b/SolStandard/Entity/Unit/CreepEntity.cs
@@ -1,19 +1,21 @@
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using SolStandard.Entity.Unit.Actions;
 using SolStandard.Utility;
+using SolStandard.Utility.Model;
 
 namespace SolStandard.Entity.Unit
 {
     public class CreepEntity : UnitEntity
     {
         private IRenderable routineIcon;
+        public CreepRoutineModel Routines { get; private set; }
 
-        public CreepEntity(string name, string type, UnitSpriteSheet spriteSheet, Vector2 mapCoordinates,
-            bool isCommander, Dictionary<string, string> tiledProperties)
-            : base(name, type, spriteSheet, mapCoordinates, isCommander, tiledProperties)
+        public CreepEntity(string name, string type, UnitSpriteSheet spriteSheet, Vector2 mapCoordinates, Team team,
+            Role role, bool isCommander, CreepRoutineModel creepRoutineRoutines, string[] initialInventory)
+            : base(name, type, spriteSheet, mapCoordinates, team, role, isCommander, initialInventory)
         {
+            Routines = creepRoutineRoutines;
         }
 
         public void UpdateRoutineIcon(IRoutine routine)
@@ -33,7 +35,7 @@ namespace SolStandard.Entity.Unit
         public override void Draw(SpriteBatch spriteBatch)
         {
             base.Draw(spriteBatch);
-            
+
             if (routineIcon != null)
             {
                 routineIcon.Draw(spriteBatch, CenterTopOfTile(MapCoordinates, routineIcon.Width));

--- a/SolStandard/Entity/Unit/CreepUnit.cs
+++ b/SolStandard/Entity/Unit/CreepUnit.cs
@@ -15,10 +15,10 @@ namespace SolStandard.Entity.Unit
 
         // ReSharper disable once SuggestBaseTypeForParameter
         public CreepUnit(string id, Team team, Role role, CreepEntity unitEntity, UnitStatistics stats,
-            ITexture2D portrait, List<UnitAction> actions, bool isBoss, IRoutine fallbackRoutine) :
-            base(id, team, role, unitEntity, stats, portrait, actions, isBoss)
+            ITexture2D portrait, bool isBoss) :
+            base(id, team, role, unitEntity, stats, portrait, unitEntity.Routines.Actions, isBoss)
         {
-            this.fallbackRoutine = fallbackRoutine;
+            fallbackRoutine = unitEntity.Routines.FallbackRoutine;
         }
 
         private CreepEntity CreepEntity

--- a/SolStandard/Entity/Unit/GameUnit.cs
+++ b/SolStandard/Entity/Unit/GameUnit.cs
@@ -77,7 +77,6 @@ namespace SolStandard.Entity.Unit
         public bool IsExhausted { get; private set; }
 
         public List<UnitAction> Actions { get; private set; }
-        public List<UnitAction> InventoryActions { get; private set; }
         public List<UnitAction> ContextualActions { get; private set; }
         private UnitAction armedUnitAction;
 
@@ -100,11 +99,6 @@ namespace SolStandard.Entity.Unit
             Actions = actions;
             IsCommander = isCommander;
             IsMovable = true;
-            InventoryActions = new List<UnitAction>
-            {
-                new DropGiveGoldAction(),
-                new Wait()
-            };
 
             ContextualActions = new List<UnitAction>();
             largePortrait = new SpriteAtlas(portrait, new Vector2(portrait.Width, portrait.Height),
@@ -690,24 +684,16 @@ namespace SolStandard.Entity.Unit
         {
             Inventory.Add(item);
 
-            if (!item.IsBroken)
-            {
-                InventoryActions.Add(item.UseAction());
-            }
-            else
+            if (item.IsBroken)
             {
                 item.Icon.DefaultColor = DeadPortraitColor;
             }
-
-            InventoryActions.Add(item.DropAction());
         }
 
         public bool RemoveItemFromInventory(IItem item)
         {
             if (Inventory.Contains(item))
             {
-                InventoryActions.Remove(InventoryActions.Find(skill => skill.Name == item.UseAction().Name));
-                InventoryActions.Remove(InventoryActions.Find(skill => skill.Name == item.DropAction().Name));
                 Inventory.Remove(item);
                 return true;
             }

--- a/SolStandard/Entity/Unit/UnitEntity.cs
+++ b/SolStandard/Entity/Unit/UnitEntity.cs
@@ -23,19 +23,26 @@ namespace SolStandard.Entity.Unit
 
         private SpriteAtlas commanderCrown;
         private bool isCommander;
+        public Team Team { get; private set; }
+        public Role Role { get; private set; }
+        public string[] InitialInventory { get; private set; }
 
-        public UnitEntity(string name, string type, UnitSpriteSheet spriteSheet, Vector2 mapCoordinates,
-            bool isCommander, Dictionary<string, string> tiledProperties)
-            : base(name, type, spriteSheet, mapCoordinates, tiledProperties)
+        public UnitEntity(string name, string type, UnitSpriteSheet spriteSheet, Vector2 mapCoordinates, Team team,
+            Role role, bool isCommander, string[] initialInventory)
+            : base(name, type, spriteSheet, mapCoordinates)
         {
             ElementColor = ActiveColor;
 
+            Team = team;
+            Role = role;
             IsCommander = isCommander;
+            this.InitialInventory = initialInventory;
         }
+
 
         public bool IsCommander
         {
-            private get { return isCommander; }
+            get { return isCommander; }
             set
             {
                 isCommander = value;

--- a/SolStandard/Entity/Unit/UnitEntity.cs
+++ b/SolStandard/Entity/Unit/UnitEntity.cs
@@ -86,7 +86,7 @@ namespace SolStandard.Entity.Unit
             return thisUnit.ContextualActions;
         }
 
-        public override void Draw(SpriteBatch spriteBatch, Color colorOverride)
+        protected override void Draw(SpriteBatch spriteBatch, Color colorOverride)
         {
             if (!Visible) return;
 

--- a/SolStandard/HUD/Menu/IMenu.cs
+++ b/SolStandard/HUD/Menu/IMenu.cs
@@ -1,3 +1,4 @@
+using SolStandard.HUD.Menu.Options;
 using SolStandard.Utility;
 
 namespace SolStandard.HUD.Menu
@@ -15,5 +16,6 @@ namespace SolStandard.HUD.Menu
         
         void MoveMenuCursor(MenuCursorDirection direction);
         void SelectOption();
+        MenuOption CurrentOption { get; }
     }
 }

--- a/SolStandard/HUD/Menu/TwoDimensionalMenu.cs
+++ b/SolStandard/HUD/Menu/TwoDimensionalMenu.cs
@@ -13,7 +13,6 @@ namespace SolStandard.HUD.Menu
 {
     public class TwoDimensionalMenu : IMenu
     {
-
         public enum CursorType
         {
             Pointer,
@@ -63,7 +62,8 @@ namespace SolStandard.HUD.Menu
         private void SetCursorPosition(int row, int column)
         {
             Vector2 optionPosition = new Vector2(
-                (column * (optionSize.X + ((menuWindow.ElementSpacing + menuWindow.InsidePadding * 2)))) + menuWindow.ElementSpacing,
+                (column * (optionSize.X + ((menuWindow.ElementSpacing + menuWindow.InsidePadding * 2)))) +
+                menuWindow.ElementSpacing,
                 row * optionSize.Y
             );
             Vector2 centerLeft =
@@ -107,9 +107,14 @@ namespace SolStandard.HUD.Menu
             }
         }
 
+        public MenuOption CurrentOption
+        {
+            get { return options[CurrentOptionRow, CurrentOptionColumn]; }
+        }
+
         public void SelectOption()
         {
-            options[CurrentOptionRow, CurrentOptionColumn].Execute();
+            CurrentOption.Execute();
             AssetManager.MenuConfirmSFX.Play();
         }
 

--- a/SolStandard/HUD/Menu/VerticalMenu.cs
+++ b/SolStandard/HUD/Menu/VerticalMenu.cs
@@ -102,7 +102,7 @@ namespace SolStandard.HUD.Menu
 
         public void SelectOption()
         {
-            options[CurrentOptionIndex].Execute();
+            CurrentOption.Execute();
             AssetManager.MenuConfirmSFX.Play();
         }
 

--- a/SolStandard/Map/Elements/Cursor/MapCursor.cs
+++ b/SolStandard/Map/Elements/Cursor/MapCursor.cs
@@ -212,7 +212,7 @@ namespace SolStandard.Map.Elements.Cursor
             Draw(spriteBatch, Color.White);
         }
 
-        public override void Draw(SpriteBatch spriteBatch, Color colorOverride)
+        protected override void Draw(SpriteBatch spriteBatch, Color colorOverride)
         {
             UpdateCursorTeam();
             UpdateRenderCoordinates();

--- a/SolStandard/Map/Elements/MapDistanceTile.cs
+++ b/SolStandard/Map/Elements/MapDistanceTile.cs
@@ -81,7 +81,7 @@ namespace SolStandard.Map.Elements
             return textTarget;
         }
 
-        public override void Draw(SpriteBatch spriteBatch, Color colorOverride)
+        protected override void Draw(SpriteBatch spriteBatch, Color colorOverride)
         {
             Sprite.Draw(spriteBatch, MapCoordinates * GameDriver.CellSize, colorOverride);
 

--- a/SolStandard/Map/Elements/MapElement.cs
+++ b/SolStandard/Map/Elements/MapElement.cs
@@ -26,7 +26,7 @@ namespace SolStandard.Map.Elements
             Draw(spriteBatch, ElementColor);
         }
 
-        public virtual void Draw(SpriteBatch spriteBatch, Color colorOverride)
+        protected virtual void Draw(SpriteBatch spriteBatch, Color colorOverride)
         {
             if (Visible) Sprite.Draw(spriteBatch, MapCoordinates * GameDriver.CellSize, colorOverride);
         }

--- a/SolStandard/Map/Elements/MapEntity.cs
+++ b/SolStandard/Map/Elements/MapEntity.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using SolStandard.Utility;
 
 namespace SolStandard.Map.Elements
@@ -12,14 +11,11 @@ namespace SolStandard.Map.Elements
     {
         private readonly string name;
         private readonly string type;
-        private readonly Dictionary<string, string> tiledProperties;
 
-        public MapEntity(string name, string type, IRenderable spriteSheet, Vector2 mapCoordinates,
-            Dictionary<string, string> tiledProperties)
+        public MapEntity(string name, string type, IRenderable spriteSheet, Vector2 mapCoordinates)
         {
             this.name = name;
             this.type = type;
-            this.tiledProperties = tiledProperties;
             Sprite = spriteSheet;
             MapCoordinates = mapCoordinates;
         }
@@ -32,11 +28,6 @@ namespace SolStandard.Map.Elements
         public string Type
         {
             get { return type; }
-        }
-
-        public Dictionary<string, string> TiledProperties
-        {
-            get { return tiledProperties; }
         }
 
         public override string ToString()

--- a/SolStandard/Map/TmxMapParser.cs
+++ b/SolStandard/Map/TmxMapParser.cs
@@ -249,7 +249,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             Convert.ToInt32(currentProperties["HP"]),
                                             Convert.ToBoolean(currentProperties["canMove"]),
                                             Convert.ToBoolean(currentProperties["isBroken"]),
@@ -266,7 +265,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             Convert.ToInt32(currentProperties["atkBonus"]),
                                             Convert.ToInt32(currentProperties["retBonus"]),
                                             Convert.ToInt32(currentProperties["blockBonus"]),
@@ -302,7 +300,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             Convert.ToBoolean(currentProperties["isLocked"]),
                                             Convert.ToBoolean(currentProperties["isOpen"]),
                                             Convert.ToBoolean(currentProperties["canMove"]),
@@ -318,8 +315,7 @@ namespace SolStandard.Map
                                             currentObject.Name,
                                             currentObject.Type,
                                             tileSprite,
-                                            new Vector2(col, row),
-                                            currentProperties
+                                            new Vector2(col, row)
                                         );
                                         break;
                                     case EntityTypes.Door:
@@ -328,7 +324,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             Convert.ToBoolean(currentProperties["isLocked"]),
                                             Convert.ToBoolean(currentProperties["isOpen"]),
                                             currentProperties["range"]
@@ -342,7 +337,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             Convert.ToBoolean(currentProperties["canMove"])
                                         );
                                         break;
@@ -352,7 +346,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             Convert.ToBoolean(currentProperties["canMove"]),
                                             currentProperties["destinationId"],
                                             currentProperties["range"]
@@ -365,7 +358,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             Convert.ToInt32(currentProperties["value"]),
                                             currentProperties["range"]
                                                 .Split(',').Select(n => Convert.ToInt32(n)).ToArray()
@@ -377,7 +369,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             currentProperties["triggersId"]
                                         );
                                         break;
@@ -387,7 +378,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             currentProperties["usedWith"],
                                             currentProperties["range"].Split(',').Select(n => Convert.ToInt32(n))
                                                 .ToArray(),
@@ -401,7 +391,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             Convert.ToBoolean(currentProperties["isOpen"])
                                         );
                                         break;
@@ -411,7 +400,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             Convert.ToBoolean(currentProperties["canMove"]),
                                             currentProperties["range"].Split(',').Select(n => Convert.ToInt32(n))
                                                 .ToArray(),
@@ -424,7 +412,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             Convert.ToBoolean(currentProperties["canMove"]),
                                             Convert.ToInt32(currentProperties["range"]),
                                             Convert.ToInt32(currentProperties["damage"])
@@ -439,7 +426,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             derivedMapInfo,
                                             currentProperties["mapSong"],
                                             new MapObjectives(
@@ -472,7 +458,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             Convert.ToBoolean(currentProperties["capturableByBlue"]),
                                             Convert.ToBoolean(currentProperties["capturableByRed"])
                                         );
@@ -482,8 +467,7 @@ namespace SolStandard.Map
                                             currentObject.Name,
                                             currentObject.Type,
                                             tileSprite,
-                                            new Vector2(col, row),
-                                            currentProperties
+                                            new Vector2(col, row)
                                         );
                                         break;
                                     case EntityTypes.PressurePlate:
@@ -492,7 +476,6 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            currentProperties,
                                             currentProperties["triggersId"],
                                             Convert.ToBoolean(currentProperties["triggerOnRelease"])
                                         );
@@ -582,8 +565,7 @@ namespace SolStandard.Map
                                             currentObject.Type,
                                             tileSprite,
                                             new Vector2(col, row),
-                                            (Team) Enum.Parse(typeof(Team), currentProperties["Team"]),
-                                            currentProperties
+                                            (Team) Enum.Parse(typeof(Team), currentProperties["Team"])
                                         );
                                         break;
                                     case EntityTypes.Bank:
@@ -595,8 +577,7 @@ namespace SolStandard.Map
                                             Convert.ToBoolean(currentProperties["canMove"]),
                                             currentProperties["interactRange"].Split(',')
                                                 .Select(n => Convert.ToInt32(n))
-                                                .ToArray(),
-                                            currentProperties
+                                                .ToArray()
                                         );
                                         break;
                                     case EntityTypes.Vendor:
@@ -631,8 +612,7 @@ namespace SolStandard.Map
                                             tileSprite,
                                             new Vector2(col, row),
                                             Convert.ToInt32(currentProperties["amrPerTurn"]),
-                                            Convert.ToInt32(currentProperties["hpPerTurn"]),
-                                            currentProperties
+                                            Convert.ToInt32(currentProperties["hpPerTurn"])
                                         );
                                         break;
                                     case EntityTypes.LadderBridge:
@@ -642,8 +622,7 @@ namespace SolStandard.Map
                                             tileSprite,
                                             new Vector2(col, row),
                                             currentProperties["itemPool"],
-                                            Convert.ToBoolean(currentProperties["canMove"]),
-                                            currentProperties
+                                            Convert.ToBoolean(currentProperties["canMove"])
                                         );
                                         break;
                                     case EntityTypes.Magnet:
@@ -670,8 +649,7 @@ namespace SolStandard.Map
                                                 .ToArray(),
                                             Convert.ToInt32(currentProperties["damage"]),
                                             Convert.ToInt32(currentProperties["turnsRemaining"]),
-                                            currentProperties["itemPool"],
-                                            currentProperties
+                                            currentProperties["itemPool"]
                                         );
                                         break;
                                     case EntityTypes.Contract:
@@ -756,18 +734,20 @@ namespace SolStandard.Map
                             ((int) currentObject.Y - GameDriver.CellSize)) continue;
 
                         int objectTileId = currentObject.Tile.Gid;
-                        if (objectTileId != 0)
-                        {
-                            Dictionary<string, string> currentProperties =
-                                GetDefaultPropertiesAndOverrides(currentObject);
-                            Team unitTeam = ObtainUnitTeam(currentProperties["Team"]);
-                            Role role = ObtainUnitClass(currentProperties["Class"]);
-                            bool isCommander = Convert.ToBoolean(currentProperties["Commander"]);
+                        if (objectTileId == 0) continue;
 
-                            unitGrid[col, row] = UnitGenerator.GenerateMapEntity(currentObject.Name,
-                                currentObject.Type, role, unitTeam, isCommander, unitSprites, new Vector2(col, row),
-                                currentProperties);
-                        }
+                        Dictionary<string, string> currentProperties = GetDefaultPropertiesAndOverrides(currentObject);
+                        Team unitTeam = ObtainUnitTeam(currentProperties["Team"]);
+                        Role role = ObtainUnitClass(currentProperties["Class"]);
+                        bool isCommander = Convert.ToBoolean(currentProperties["Commander"]);
+                        string itemsList = (currentProperties.ContainsKey("Items"))
+                            ? currentProperties["Items"]
+                            : string.Empty;
+                        string[] unitInventory = (itemsList == string.Empty) ? new string[0] : itemsList.Split('|');
+
+                        unitGrid[col, row] = UnitGenerator.GenerateMapEntity(currentObject.Name,
+                            currentObject.Type, role, unitTeam, isCommander, unitInventory, unitSprites,
+                            new Vector2(col, row), currentProperties);
                     }
                 }
             }

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -163,8 +163,10 @@
     <Compile Include="Entity\Unit\Actions\Item\DeployBombAction.cs" />
     <Compile Include="Entity\Unit\Actions\Item\DeployLadderBridgeAction.cs" />
     <Compile Include="Entity\Unit\Actions\Item\DeployRecallPointAction.cs" />
+    <Compile Include="Entity\Unit\Actions\Item\DropGiveItemAction.cs" />
     <Compile Include="Entity\Unit\Actions\Item\MagneticPullAction.cs" />
     <Compile Include="Entity\Unit\Actions\Item\ReturnToRecallPointAction.cs" />
+    <Compile Include="Entity\Unit\Actions\Item\TradeItemAction.cs" />
     <Compile Include="Entity\Unit\Actions\ITurnProc.cs" />
     <Compile Include="Entity\Unit\Actions\IIncrementableAction.cs" />
     <Compile Include="Entity\Unit\Actions\IRoutine.cs" />
@@ -196,7 +198,6 @@
     <Compile Include="Entity\Unit\Actions\Terrain\BankDeposit.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\BankWithdraw.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\EscapeAction.cs" />
-    <Compile Include="Entity\Unit\Actions\Terrain\TradeItemAction.cs" />
     <Compile Include="Entity\Unit\Actions\Sprint.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\VendorPurchase.cs" />
     <Compile Include="Entity\Unit\CreepEntity.cs" />
@@ -209,7 +210,6 @@
     <Compile Include="Entity\Unit\Actions\Bard\Accelerando.cs" />
     <Compile Include="Entity\Unit\Actions\Bard\Capriccio.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\ArtilleryAction.cs" />
-    <Compile Include="Entity\Unit\Actions\Terrain\DropGiveItemAction.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\PickUpCurrencyAction.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\PickUpItemAction.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\PushBlockAction.cs" />

--- a/SolStandard/Utility/Buttons/ControlMapper.cs
+++ b/SolStandard/Utility/Buttons/ControlMapper.cs
@@ -26,10 +26,10 @@ namespace SolStandard.Utility.Buttons
         PreviewItem,
         Status,
         Menu,
-        LeftBumper,
-        RightBumper,
-        LeftTrigger,
-        RightTrigger
+        TabLeft,
+        TabRight,
+        ZoomOut,
+        ZoomIn
     }
 
     public abstract class ControlMapper

--- a/SolStandard/Utility/Buttons/GameControlParser.cs
+++ b/SolStandard/Utility/Buttons/GameControlParser.cs
@@ -29,10 +29,10 @@ namespace SolStandard.Utility.Buttons
                 {Input.PreviewUnit, controller.ResetToUnit},
                 {Input.PreviewItem, controller.CenterCamera},
 
-                {Input.LeftBumper, controller.SetWideZoom},
-                {Input.RightBumper, controller.SetCloseZoom},
-                {Input.LeftTrigger, controller.AdjustZoomOut},
-                {Input.RightTrigger, controller.AdjustZoomIn},
+                {Input.TabLeft, controller.SetWideZoom},
+                {Input.TabRight, controller.SetCloseZoom},
+                {Input.ZoomOut, controller.AdjustZoomOut},
+                {Input.ZoomIn, controller.AdjustZoomIn},
             };
         }
 

--- a/SolStandard/Utility/Buttons/Gamepad/GamepadController.cs
+++ b/SolStandard/Utility/Buttons/Gamepad/GamepadController.cs
@@ -29,10 +29,10 @@ namespace SolStandard.Utility.Buttons.Gamepad
             {Input.Menu, ButtonIcon.Menu},
             {Input.Status, ButtonIcon.Windows},
 
-            {Input.LeftBumper, ButtonIcon.Lb},
-            {Input.RightBumper, ButtonIcon.Rb},
-            {Input.LeftTrigger, ButtonIcon.Lt},
-            {Input.RightTrigger, ButtonIcon.Rt},
+            {Input.TabLeft, ButtonIcon.Lb},
+            {Input.TabRight, ButtonIcon.Rb},
+            {Input.ZoomOut, ButtonIcon.Lt},
+            {Input.ZoomIn, ButtonIcon.Rt},
         };
 
         public GamepadController(PlayerIndex playerIndex)
@@ -80,10 +80,10 @@ namespace SolStandard.Utility.Buttons.Gamepad
                 {Input.Menu, Menu},
                 {Input.Status, Status},
 
-                {Input.LeftBumper, SetWideZoom},
-                {Input.RightBumper, SetCloseZoom},
-                {Input.LeftTrigger, AdjustZoomOut},
-                {Input.RightTrigger, AdjustZoomIn},
+                {Input.TabLeft, SetWideZoom},
+                {Input.TabRight, SetCloseZoom},
+                {Input.ZoomOut, AdjustZoomOut},
+                {Input.ZoomIn, AdjustZoomIn},
             };
         }
 

--- a/SolStandard/Utility/Buttons/KeyboardInput/KeyboardController.cs
+++ b/SolStandard/Utility/Buttons/KeyboardInput/KeyboardController.cs
@@ -30,10 +30,10 @@ namespace SolStandard.Utility.Buttons.KeyboardInput
             {Input.Menu, KeyboardIcon.Enter},
             {Input.Status, KeyboardIcon.Escape},
 
-            {Input.LeftBumper, KeyboardIcon.Tab},
-            {Input.RightBumper, KeyboardIcon.R},
-            {Input.LeftTrigger, KeyboardIcon.LeftCtrl},
-            {Input.RightTrigger, KeyboardIcon.LeftAlt},
+            {Input.TabLeft, KeyboardIcon.Tab},
+            {Input.TabRight, KeyboardIcon.R},
+            {Input.ZoomOut, KeyboardIcon.LeftCtrl},
+            {Input.ZoomIn, KeyboardIcon.LeftAlt},
         };
 
         public KeyboardController()
@@ -81,10 +81,10 @@ namespace SolStandard.Utility.Buttons.KeyboardInput
                 {Input.Menu, (InputKey) Menu},
                 {Input.Status, (InputKey) Status},
 
-                {Input.LeftBumper, (InputKey) SetWideZoom},
-                {Input.RightBumper, (InputKey) SetCloseZoom},
-                {Input.LeftTrigger, (InputKey) AdjustZoomOut},
-                {Input.RightTrigger, (InputKey) AdjustZoomIn},
+                {Input.TabLeft, (InputKey) SetWideZoom},
+                {Input.TabRight, (InputKey) SetCloseZoom},
+                {Input.ZoomOut, (InputKey) AdjustZoomOut},
+                {Input.ZoomIn, (InputKey) AdjustZoomIn},
             };
         }
 

--- a/SolStandard/Utility/Buttons/Network/NetworkController.cs
+++ b/SolStandard/Utility/Buttons/Network/NetworkController.cs
@@ -59,10 +59,10 @@ namespace SolStandard.Utility.Buttons.Network
                 {Input.Menu, (InputNet) Menu},
                 {Input.Status, (InputNet) Status},
 
-                {Input.LeftBumper, (InputNet) SetWideZoom},
-                {Input.RightBumper, (InputNet) SetCloseZoom},
-                {Input.LeftTrigger, (InputNet) AdjustZoomOut},
-                {Input.RightTrigger, (InputNet) AdjustZoomIn},
+                {Input.TabLeft, (InputNet) SetWideZoom},
+                {Input.TabRight, (InputNet) SetCloseZoom},
+                {Input.ZoomOut, (InputNet) AdjustZoomOut},
+                {Input.ZoomIn, (InputNet) AdjustZoomIn},
             };
         }
 
@@ -152,10 +152,10 @@ namespace SolStandard.Utility.Buttons.Network
             info.AddValue(NCPrefix + (int) Input.CameraRight, CameraRight.Pressed);
             info.AddValue(NCPrefix + (int) Input.Menu, Menu.Pressed);
             info.AddValue(NCPrefix + (int) Input.Status, Status.Pressed);
-            info.AddValue(NCPrefix + (int) Input.LeftBumper, SetWideZoom.Pressed);
-            info.AddValue(NCPrefix + (int) Input.RightBumper, SetCloseZoom.Pressed);
-            info.AddValue(NCPrefix + (int) Input.LeftTrigger, AdjustZoomOut.Pressed);
-            info.AddValue(NCPrefix + (int) Input.RightTrigger, AdjustZoomIn.Pressed);
+            info.AddValue(NCPrefix + (int) Input.TabLeft, SetWideZoom.Pressed);
+            info.AddValue(NCPrefix + (int) Input.TabRight, SetCloseZoom.Pressed);
+            info.AddValue(NCPrefix + (int) Input.ZoomOut, AdjustZoomOut.Pressed);
+            info.AddValue(NCPrefix + (int) Input.ZoomIn, AdjustZoomIn.Pressed);
         }
 
         public override bool Equals(object networkController)
@@ -222,10 +222,10 @@ namespace SolStandard.Utility.Buttons.Network
             description += string.Format("<{0}: {1}>, ", Input.Menu.ToString(), Menu);
             description += string.Format("<{0}: {1}>, ", Input.Status.ToString(), Status);
             description += Environment.NewLine;
-            description += string.Format("<{0}: {1}>, ", Input.LeftBumper.ToString(), SetWideZoom);
-            description += string.Format("<{0}: {1}>, ", Input.RightBumper.ToString(), SetCloseZoom);
-            description += string.Format("<{0}: {1}>, ", Input.LeftTrigger.ToString(), AdjustZoomOut);
-            description += string.Format("<{0}: {1}>", Input.RightTrigger.ToString(), AdjustZoomIn);
+            description += string.Format("<{0}: {1}>, ", Input.TabLeft.ToString(), SetWideZoom);
+            description += string.Format("<{0}: {1}>, ", Input.TabRight.ToString(), SetCloseZoom);
+            description += string.Format("<{0}: {1}>, ", Input.ZoomOut.ToString(), AdjustZoomOut);
+            description += string.Format("<{0}: {1}>", Input.ZoomIn.ToString(), AdjustZoomIn);
             description += Environment.NewLine;
             description += "}";
 

--- a/SolStandard/Utility/Events/Network/ToggleCombatMenuEvent.cs
+++ b/SolStandard/Utility/Events/Network/ToggleCombatMenuEvent.cs
@@ -8,7 +8,7 @@ namespace SolStandard.Utility.Events.Network
     {
         public override void Continue()
         {
-            GameContext.GameMapContext.ToggleCombatMenu();
+            GameContext.GameMapContext.ToggleActionInventoryMenu();
             Complete = true;
         }
     }


### PR DESCRIPTION
- Resolved technical debt that intertwined loose parsing of TiledProperties throughout the codebase.
- Reworked inventory to show item usage and drop/give actions side-by-side in a 2D menu instead of a vertical menu.
- Fixed bug in map select for escape map that had wrong unit count for Red Team.
- Minor control changes to inventory and action menus.
- Renamed input enum values to better represent their function.