### PR TITLE
Sol 43 new entities and maps

### DIFF
--- a/SolStandard/Containers/Contexts/ControlContext.cs
+++ b/SolStandard/Containers/Contexts/ControlContext.cs
@@ -645,7 +645,7 @@ namespace SolStandard.Containers.Contexts
         {
             if (controlMapper.Press(Input.Confirm, PressType.Single))
             {
-                GlobalEventQueue.QueueSingleEvent(new ResolveTurnEvent());
+                GlobalEventQueue.QueueSingleEvent(new ResolveNetworkTurnEvent());
             }
         }
 

--- a/SolStandard/Containers/Contexts/GameMapContext.cs
+++ b/SolStandard/Containers/Contexts/GameMapContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Xna.Framework;
@@ -86,7 +87,6 @@ namespace SolStandard.Containers.Contexts
         {
             if (GameContext.CurrentGameState == GameContext.GameState.Results) return;
 
-            TriggerEffectTilesTurnEnd();
             GameContext.Scenario.CheckForWinState();
             UpdateUnitMorale(Team.Blue);
             UpdateUnitMorale(Team.Red);
@@ -566,49 +566,55 @@ namespace SolStandard.Containers.Contexts
             return currentActionOption.Action as IIncrementableAction;
         }
 
-        public static void TriggerEffectTilesTurnStart()
+        /// <summary>
+        /// Trigger all effect tiles that are set to trigger at the specified time.
+        /// </summary>
+        /// <param name="effectTriggerTime"></param>
+        /// <returns>True if any tile can trigger this phase.</returns>
+        public static bool TriggerEffectTiles(EffectTriggerTime effectTriggerTime)
         {
             List<IEffectTile> effectTiles = MapContainer.GameGrid[(int) Layer.Entities].OfType<IEffectTile>().ToList();
+            List<IEffectTile> triggerTiles = effectTiles.Where(tile => tile.WillTrigger(effectTriggerTime)).ToList();
 
-            if (effectTiles.Count <= 0) return;
+            if (triggerTiles.Count <= 0)
+            {
+                effectTiles.ForEach(tile => tile.HasTriggered = false);
+                return false;
+            }
 
-            Queue<IEvent> startOfTurnEffectTileEvents = new Queue<IEvent>();
-            startOfTurnEffectTileEvents.Enqueue(
+            Queue<IEvent> effectTileEvents = new Queue<IEvent>();
+            effectTileEvents.Enqueue(
                 new ToastAtCursorEvent(
-                    "Resolving Tile Effects...",
+                    "Resolving " + effectTriggerTime + " Tile Effects...",
                     AssetManager.MenuConfirmSFX,
                     100
                 )
             );
-            startOfTurnEffectTileEvents.Enqueue(new WaitFramesEvent(50));
 
-            foreach (IEffectTile tile in effectTiles.Where(tile => tile.WillTrigger(EffectTriggerTime.StartOfTurn)))
+            foreach (IEffectTile tile in triggerTiles)
             {
-                startOfTurnEffectTileEvents.Enqueue(new TriggerEffectTileEvent(tile, EffectTriggerTime.StartOfTurn,
-                    50));
-            }
-
-            startOfTurnEffectTileEvents.Enqueue(new RemoveExpiredEffectTilesEvent(effectTiles));
-
-            GlobalEventQueue.QueueEvents(startOfTurnEffectTileEvents);
-        }
-
-        private static void TriggerEffectTilesTurnEnd()
-        {
-            List<IEffectTile> effectTiles = MapContainer.GameGrid[(int) Layer.Entities].OfType<IEffectTile>().ToList();
-
-            if (effectTiles.Count <= 0) return;
-
-            Queue<IEvent> endOfTurnEffectTileEvents = new Queue<IEvent>();
-            foreach (IEffectTile tile in effectTiles.Where(tile => tile.WillTrigger(EffectTriggerTime.EndOfTurn)))
-            {
-                endOfTurnEffectTileEvents.Enqueue(
-                    new TriggerEffectTileEvent(tile, EffectTriggerTime.EndOfTurn, 80)
+                effectTileEvents.Enqueue(
+                    new TriggerSingleEffectTileEvent(tile, effectTriggerTime, 50)
                 );
             }
 
-            endOfTurnEffectTileEvents.Enqueue(new RemoveExpiredEffectTilesEvent(effectTiles));
-            GlobalEventQueue.QueueEvents(endOfTurnEffectTileEvents);
+            effectTileEvents.Enqueue(new RemoveExpiredEffectTilesEvent(triggerTiles));
+
+            switch (effectTriggerTime)
+            {
+                case EffectTriggerTime.StartOfRound:
+                    effectTileEvents.Enqueue(new EffectTilesStartOfRoundEvent());
+                    break;
+                case EffectTriggerTime.EndOfTurn:
+                    effectTileEvents.Enqueue(new EndTurnEvent());
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(effectTriggerTime), effectTriggerTime, null);
+            }
+
+            GlobalEventQueue.QueueEvents(effectTileEvents);
+
+            return true;
         }
 
         public static void RemoveExpiredEffectTiles(IEnumerable<IEffectTile> effectTiles)

--- a/SolStandard/Containers/Contexts/GameMapContext.cs
+++ b/SolStandard/Containers/Contexts/GameMapContext.cs
@@ -46,6 +46,8 @@ namespace SolStandard.Containers.Contexts
         public int RoundCounter { get; private set; }
         public bool CanCancelAction { get; set; }
         private GameUnit HoverUnit { get; set; }
+        private TerrainEntity lastHoverEntity { get; set; }
+        private TerrainEntity lastHoverItem { get;set; }
 
         private readonly Dictionary<Direction, UnitAnimationState> directionToAnimation =
             new Dictionary<Direction, UnitAnimationState>
@@ -473,6 +475,8 @@ namespace SolStandard.Containers.Contexts
             GameMapView.SetEntityWindow(hoverSlice);
 
             HoverUnit = hoverMapUnit;
+            lastHoverEntity = hoverSlice.TerrainEntity;
+            lastHoverItem = hoverSlice.ItemEntity;
         }
 
         private void UpdateThreatRangePreview(GameUnit hoverMapUnit, MapSlice hoverSlice)
@@ -487,8 +491,8 @@ namespace SolStandard.Containers.Contexts
             }
             else if (hoverSlice.TerrainEntity is IThreatRange entityThreat)
             {
+                if (lastHoverEntity == hoverSlice.TerrainEntity && lastHoverItem == hoverSlice.ItemEntity) return;
                 MapContainer.ClearDynamicAndPreviewGrids();
-
                 new UnitTargetingContext(MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Attack))
                     .GenerateThreatGrid(hoverSlice.MapCoordinates, entityThreat);
             }

--- a/SolStandard/Containers/Contexts/GameMapContext.cs
+++ b/SolStandard/Containers/Contexts/GameMapContext.cs
@@ -583,6 +583,7 @@ namespace SolStandard.Containers.Contexts
             }
 
             Queue<IEvent> effectTileEvents = new Queue<IEvent>();
+            effectTileEvents.Enqueue(new WaitFramesEvent(10));
             effectTileEvents.Enqueue(
                 new ToastAtCursorEvent(
                     "Resolving " + effectTriggerTime + " Tile Effects...",
@@ -590,11 +591,13 @@ namespace SolStandard.Containers.Contexts
                     100
                 )
             );
+            effectTileEvents.Enqueue(new WaitFramesEvent(50));
 
             foreach (IEffectTile tile in triggerTiles)
             {
+                effectTileEvents.Enqueue(new CameraCursorPositionEvent(tile.MapCoordinates));
                 effectTileEvents.Enqueue(
-                    new TriggerSingleEffectTileEvent(tile, effectTriggerTime, 50)
+                    new TriggerSingleEffectTileEvent(tile, effectTriggerTime, 60)
                 );
             }
 

--- a/SolStandard/Containers/Contexts/GameMapContext.cs
+++ b/SolStandard/Containers/Contexts/GameMapContext.cs
@@ -46,8 +46,8 @@ namespace SolStandard.Containers.Contexts
         public int RoundCounter { get; private set; }
         public bool CanCancelAction { get; set; }
         private GameUnit HoverUnit { get; set; }
-        private TerrainEntity lastHoverEntity { get; set; }
-        private TerrainEntity lastHoverItem { get;set; }
+        private TerrainEntity LastHoverEntity { get; set; }
+        private TerrainEntity LastHoverItem { get;set; }
 
         private readonly Dictionary<Direction, UnitAnimationState> directionToAnimation =
             new Dictionary<Direction, UnitAnimationState>
@@ -475,8 +475,8 @@ namespace SolStandard.Containers.Contexts
             GameMapView.SetEntityWindow(hoverSlice);
 
             HoverUnit = hoverMapUnit;
-            lastHoverEntity = hoverSlice.TerrainEntity;
-            lastHoverItem = hoverSlice.ItemEntity;
+            LastHoverEntity = hoverSlice.TerrainEntity;
+            LastHoverItem = hoverSlice.ItemEntity;
         }
 
         private void UpdateThreatRangePreview(GameUnit hoverMapUnit, MapSlice hoverSlice)
@@ -491,7 +491,7 @@ namespace SolStandard.Containers.Contexts
             }
             else if (hoverSlice.TerrainEntity is IThreatRange entityThreat)
             {
-                if (lastHoverEntity == hoverSlice.TerrainEntity && lastHoverItem == hoverSlice.ItemEntity) return;
+                if (LastHoverEntity == hoverSlice.TerrainEntity && LastHoverItem == hoverSlice.ItemEntity) return;
                 MapContainer.ClearDynamicAndPreviewGrids();
                 new UnitTargetingContext(MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Attack))
                     .GenerateThreatGrid(hoverSlice.MapCoordinates, entityThreat);

--- a/SolStandard/Containers/Contexts/GameMapContext.cs
+++ b/SolStandard/Containers/Contexts/GameMapContext.cs
@@ -656,6 +656,7 @@ namespace SolStandard.Containers.Contexts
         public void ClearDraftMenu()
         {
             GameMapView.CloseAdHocDraftMenu();
+            MapContainer.ClearDynamicAndPreviewGrids();
         }
 
         public void ToggleActionInventoryMenu()

--- a/SolStandard/Containers/Contexts/InitiativeContext.cs
+++ b/SolStandard/Containers/Contexts/InitiativeContext.cs
@@ -119,7 +119,7 @@ namespace SolStandard.Containers.Contexts
             GlobalEventQueue.QueueEvents(newRoundEvents);
 
             RefreshAllUnits();
-            GameMapContext.TriggerEffectTilesTurnStart();
+            GlobalEventQueue.QueueSingleEvent(new EffectTilesStartOfRoundEvent());
 
             GlobalEventQueue.QueueSingleEvent(new UpdateTurnOrderEvent(this));
         }

--- a/SolStandard/Containers/Contexts/UnitMovingContext.cs
+++ b/SolStandard/Containers/Contexts/UnitMovingContext.cs
@@ -136,7 +136,7 @@ namespace SolStandard.Containers.Contexts
 
         public static bool CanEndMoveAtCoordinates(Vector2 coordinates)
         {
-            return CanEndMoveAtCoordinates(GameContext.ActiveUnit.UnitEntity, coordinates);
+            return CanEndMoveAtCoordinates(GameContext.ActiveUnit?.UnitEntity, coordinates);
         }
 
         public static bool CanEndMoveAtCoordinates(UnitEntity unitEntityEndingMove, Vector2 coordinates)

--- a/SolStandard/Containers/Contexts/UnitMovingContext.cs
+++ b/SolStandard/Containers/Contexts/UnitMovingContext.cs
@@ -134,15 +134,19 @@ namespace SolStandard.Containers.Contexts
             }
         }
 
-
         public static bool CanEndMoveAtCoordinates(Vector2 coordinates)
+        {
+            return CanEndMoveAtCoordinates(GameContext.ActiveUnit.UnitEntity, coordinates);
+        }
+
+        public static bool CanEndMoveAtCoordinates(UnitEntity unitEntityEndingMove, Vector2 coordinates)
         {
             if (!GameMapContext.CoordinatesWithinMapBounds(coordinates)) return false;
 
             MapSlice slice = MapContainer.GetMapSliceAtCoordinates(coordinates);
 
             if (slice.UnitEntity != null &&
-                (GameContext.ActiveUnit == null || slice.UnitEntity != GameContext.ActiveUnit.UnitEntity)) return false;
+                (GameContext.ActiveUnit == null || slice.UnitEntity != unitEntityEndingMove)) return false;
 
             if (slice.TerrainEntity != null)
             {

--- a/SolStandard/Containers/View/GameMapView.cs
+++ b/SolStandard/Containers/View/GameMapView.cs
@@ -395,6 +395,11 @@ namespace SolStandard.Containers.View
                     new IRenderable[,]
                     {
                         {
+                            new RenderText(AssetManager.WindowFont,
+                                $"X: {GameContext.MapCursor.MapCoordinates.X}, Y: {GameContext.MapCursor.MapCoordinates.Y}"),
+                            new RenderBlank()
+                        },
+                        {
                             new RenderText(AssetManager.WindowFont, "None"),
                             new RenderBlank()
                         },

--- a/SolStandard/Containers/View/GameMapView.cs
+++ b/SolStandard/Containers/View/GameMapView.cs
@@ -396,7 +396,7 @@ namespace SolStandard.Containers.View
                     {
                         {
                             new RenderText(AssetManager.WindowFont,
-                                $"X: {GameContext.MapCursor.MapCoordinates.X}, Y: {GameContext.MapCursor.MapCoordinates.Y}"),
+                                $"[ X: {GameContext.MapCursor.MapCoordinates.X}, Y: {GameContext.MapCursor.MapCoordinates.Y} ]"),
                             new RenderBlank()
                         },
                         {
@@ -409,7 +409,8 @@ namespace SolStandard.Containers.View
                                 (canMove) ? TerrainEntity.PositiveColor : TerrainEntity.NegativeColor)
                         }
                     },
-                    1
+                    1,
+                    HorizontalAlignment.Centered
                 );
 
                 terrainContentGrid = new WindowContentGrid(

--- a/SolStandard/Content/Content.mgcb
+++ b/SolStandard/Content/Content.mgcb
@@ -1718,6 +1718,18 @@
 /processorParam:TextureFormat=Color
 /build:Graphics/Images/Dice/AttackDiceAtlas.png
 
+#begin Graphics/Images/Icons/Misc/CliffJump.png
+/importer:TextureImporter
+/processor:TextureProcessor
+/processorParam:ColorKeyColor=255,0,255,255
+/processorParam:ColorKeyEnabled=True
+/processorParam:GenerateMipmaps=False
+/processorParam:PremultiplyAlpha=True
+/processorParam:ResizeToPowerOfTwo=False
+/processorParam:MakeSquare=False
+/processorParam:TextureFormat=Color
+/build:Graphics/Images/Icons/Misc/CliffJump.png
+
 #begin Graphics/Images/Icons/Misc/clock.png
 /importer:TextureImporter
 /processor:TextureProcessor

--- a/SolStandard/Content/Content.mgcb
+++ b/SolStandard/Content/Content.mgcb
@@ -1838,6 +1838,18 @@
 /processorParam:TextureFormat=Color
 /build:Graphics/Images/Icons/Misc/Launchpad.png
 
+#begin Graphics/Images/Icons/Misc/Lock.png
+/importer:TextureImporter
+/processor:TextureProcessor
+/processorParam:ColorKeyColor=255,0,255,255
+/processorParam:ColorKeyEnabled=True
+/processorParam:GenerateMipmaps=False
+/processorParam:PremultiplyAlpha=True
+/processorParam:ResizeToPowerOfTwo=False
+/processorParam:MakeSquare=False
+/processorParam:TextureFormat=Color
+/build:Graphics/Images/Icons/Misc/Lock.png
+
 #begin Graphics/Images/Icons/Misc/old_spoils.png
 /importer:TextureImporter
 /processor:TextureProcessor
@@ -1849,6 +1861,18 @@
 /processorParam:MakeSquare=False
 /processorParam:TextureFormat=Color
 /build:Graphics/Images/Icons/Misc/old_spoils.png
+
+#begin Graphics/Images/Icons/Misc/open.png
+/importer:TextureImporter
+/processor:TextureProcessor
+/processorParam:ColorKeyColor=255,0,255,255
+/processorParam:ColorKeyEnabled=True
+/processorParam:GenerateMipmaps=False
+/processorParam:PremultiplyAlpha=True
+/processorParam:ResizeToPowerOfTwo=False
+/processorParam:MakeSquare=False
+/processorParam:TextureFormat=Color
+/build:Graphics/Images/Icons/Misc/open.png
 
 #begin Graphics/Images/Icons/Misc/Piston.png
 /importer:TextureImporter

--- a/SolStandard/Content/Content.mgcb
+++ b/SolStandard/Content/Content.mgcb
@@ -2378,6 +2378,18 @@
 /processorParam:TextureFormat=Color
 /build:Graphics/Images/Icons/Skill/Recover.png
 
+#begin Graphics/Images/Icons/Skill/Rescue.png
+/importer:TextureImporter
+/processor:TextureProcessor
+/processorParam:ColorKeyColor=255,0,255,255
+/processorParam:ColorKeyEnabled=True
+/processorParam:GenerateMipmaps=False
+/processorParam:PremultiplyAlpha=True
+/processorParam:ResizeToPowerOfTwo=False
+/processorParam:MakeSquare=False
+/processorParam:TextureFormat=Color
+/build:Graphics/Images/Icons/Skill/Rescue.png
+
 #begin Graphics/Images/Icons/Skill/Shove.png
 /importer:TextureImporter
 /processor:TextureProcessor

--- a/SolStandard/Content/Content.mgcb
+++ b/SolStandard/Content/Content.mgcb
@@ -1826,6 +1826,18 @@
 /processorParam:TextureFormat=Color
 /build:Graphics/Images/Icons/Misc/Interact.png
 
+#begin Graphics/Images/Icons/Misc/Launchpad.png
+/importer:TextureImporter
+/processor:TextureProcessor
+/processorParam:ColorKeyColor=255,0,255,255
+/processorParam:ColorKeyEnabled=True
+/processorParam:GenerateMipmaps=False
+/processorParam:PremultiplyAlpha=True
+/processorParam:ResizeToPowerOfTwo=False
+/processorParam:MakeSquare=False
+/processorParam:TextureFormat=Color
+/build:Graphics/Images/Icons/Misc/Launchpad.png
+
 #begin Graphics/Images/Icons/Misc/old_spoils.png
 /importer:TextureImporter
 /processor:TextureProcessor
@@ -1837,6 +1849,18 @@
 /processorParam:MakeSquare=False
 /processorParam:TextureFormat=Color
 /build:Graphics/Images/Icons/Misc/old_spoils.png
+
+#begin Graphics/Images/Icons/Misc/Piston.png
+/importer:TextureImporter
+/processor:TextureProcessor
+/processorParam:ColorKeyColor=255,0,255,255
+/processorParam:ColorKeyEnabled=True
+/processorParam:GenerateMipmaps=False
+/processorParam:PremultiplyAlpha=True
+/processorParam:ResizeToPowerOfTwo=False
+/processorParam:MakeSquare=False
+/processorParam:TextureFormat=Color
+/build:Graphics/Images/Icons/Misc/Piston.png
 
 #begin Graphics/Images/Icons/Misc/RecoverArmor.png
 /importer:TextureImporter

--- a/SolStandard/Content/Content.mgcb
+++ b/SolStandard/Content/Content.mgcb
@@ -2222,6 +2222,18 @@
 /processorParam:TextureFormat=Color
 /build:Graphics/Images/Icons/Skill/Intervention.png
 
+#begin Graphics/Images/Icons/Skill/Jump.png
+/importer:TextureImporter
+/processor:TextureProcessor
+/processorParam:ColorKeyColor=255,0,255,255
+/processorParam:ColorKeyEnabled=True
+/processorParam:GenerateMipmaps=False
+/processorParam:PremultiplyAlpha=True
+/processorParam:ResizeToPowerOfTwo=False
+/processorParam:MakeSquare=False
+/processorParam:TextureFormat=Color
+/build:Graphics/Images/Icons/Skill/Jump.png
+
 #begin Graphics/Images/Icons/Skill/Kingslayer.png
 /importer:TextureImporter
 /processor:TextureProcessor

--- a/SolStandard/Content/TmxMaps/00_DRAFT_TEMPLATE.tmx
+++ b/SolStandard/Content/TmxMaps/00_DRAFT_TEMPLATE.tmx
@@ -1938,62 +1938,62 @@
   </data>
  </layer>
  <objectgroup id="5" name="Entities">
-  <object id="959" name="Deploy Blue" type="Deployment" gid="6342" x="832" y="128" width="32" height="32">
+  <object id="959" name="Deploy Blue" type="Deployment" gid="6342" x="160" y="128" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="960" name="Deploy Red" type="Deployment" gid="6350" x="96" y="192" width="32" height="32">
+  <object id="960" name="Deploy Red" type="Deployment" gid="6350" x="832" y="128" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="973" name="Deploy Blue" type="Deployment" gid="6342" x="864" y="160" width="32" height="32">
+  <object id="973" name="Deploy Blue" type="Deployment" gid="6342" x="64" y="160" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="974" name="Deploy Blue" type="Deployment" gid="6342" x="896" y="192" width="32" height="32">
+  <object id="974" name="Deploy Blue" type="Deployment" gid="6342" x="96" y="192" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="975" name="Deploy Red" type="Deployment" gid="6350" x="128" y="160" width="32" height="32">
+  <object id="975" name="Deploy Red" type="Deployment" gid="6350" x="896" y="192" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="976" name="Deploy Red" type="Deployment" gid="6350" x="160" y="128" width="32" height="32">
+  <object id="976" name="Deploy Red" type="Deployment" gid="6350" x="928" y="160" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="977" name="Deploy Red" type="Deployment" gid="6350" x="128" y="96" width="32" height="32">
+  <object id="977" name="Deploy Red" type="Deployment" gid="6350" x="896" y="128" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="978" name="Deploy Red" type="Deployment" gid="6350" x="96" y="128" width="32" height="32">
+  <object id="978" name="Deploy Red" type="Deployment" gid="6350" x="864" y="160" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="979" name="Deploy Red" type="Deployment" gid="6350" x="64" y="160" width="32" height="32">
+  <object id="979" name="Deploy Red" type="Deployment" gid="6350" x="864" y="96" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="980" name="Deploy Blue" type="Deployment" gid="6342" x="864" y="96" width="32" height="32">
+  <object id="980" name="Deploy Blue" type="Deployment" gid="6342" x="128" y="96" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="981" name="Deploy Blue" type="Deployment" gid="6342" x="896" y="128" width="32" height="32">
+  <object id="981" name="Deploy Blue" type="Deployment" gid="6342" x="96" y="128" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="982" name="Deploy Blue" type="Deployment" gid="6342" x="928" y="160" width="32" height="32">
+  <object id="982" name="Deploy Blue" type="Deployment" gid="6342" x="128" y="160" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
@@ -2018,8 +2018,9 @@
   </object>
  </objectgroup>
  <objectgroup id="7" name="Items"/>
- <objectgroup id="8" name="Units">
-  <object id="963" name="Slime" type="Creep" gid="21" x="288" y="288" width="32" height="32">
+ <objectgroup id="8" name="Units"/>
+ <objectgroup id="9" name="Disabled" opacity="0.24">
+  <object id="963" name="Slime" type="Creep" gid="21" x="320" y="32" width="32" height="32">
    <properties>
     <property name="Class" value="Slime"/>
     <property name="routine_glutton" type="bool" value="true"/>
@@ -2028,7 +2029,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="965" name="Orc" type="Creep" gid="23" x="384" y="224" width="32" height="32">
+  <object id="965" name="Orc" type="Creep" gid="23" x="192" y="32" width="32" height="32">
    <properties>
     <property name="Class" value="Orc"/>
     <property name="routine_glutton" type="bool" value="true"/>
@@ -2037,7 +2038,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="966" name="Rat" type="Creep" gid="29" x="736" y="256" width="32" height="32">
+  <object id="966" name="Rat" type="Creep" gid="29" x="256" y="32" width="32" height="32">
    <properties>
     <property name="Class" value="Rat"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
@@ -2045,19 +2046,19 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="967" name="Bat" type="Creep" gid="30" x="416" y="448" width="32" height="32">
+  <object id="967" name="Bat" type="Creep" gid="30" x="288" y="32" width="32" height="32">
    <properties>
     <property name="Class" value="Bat"/>
     <property name="routine_prey" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="968" name="Spider" type="Creep" gid="28" x="640" y="384" width="32" height="32">
+  <object id="968" name="Spider" type="Creep" gid="28" x="352" y="32" width="32" height="32">
    <properties>
     <property name="Class" value="Spider"/>
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="969" name="Goblin" type="Creep" gid="27" x="544" y="352" width="32" height="32">
+  <object id="969" name="Goblin" type="Creep" gid="27" x="224" y="32" width="32" height="32">
    <properties>
     <property name="Class" value="Goblin"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
@@ -2066,7 +2067,7 @@
     <property name="routine_triggerHappy" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="970" name="Troll" type="Creep" gid="22" x="192" y="384" width="32" height="32">
+  <object id="970" name="Troll" type="Creep" gid="22" x="160" y="32" width="32" height="32">
    <properties>
     <property name="Class" value="Troll"/>
     <property name="Independent" type="bool" value="true"/>
@@ -2075,7 +2076,7 @@
     <property name="routine_prey" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="972" name="Necromancer" type="Creep" gid="25" x="576" y="160" width="32" height="32">
+  <object id="972" name="Necromancer" type="Creep" gid="25" x="128" y="32" width="32" height="32">
    <properties>
     <property name="Class" value="Necromancer"/>
     <property name="Commander" type="bool" value="true"/>
@@ -2088,7 +2089,6 @@
    </properties>
   </object>
  </objectgroup>
- <objectgroup id="9" name="Disabled" opacity="0.24"/>
  <layer id="4" name="Overlay" width="32" height="20">
   <data>
    <tile/>

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="11" nextobjectid="987">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="11" nextobjectid="994">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -1531,7 +1531,7 @@
    <tile/>
    <tile/>
    <tile/>
-   <tile/>
+   <tile gid="5671"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1560,16 +1560,16 @@
    <tile gid="5605"/>
    <tile gid="5607"/>
    <tile/>
+   <tile gid="5671"/>
+   <tile gid="5671"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5671"/>
    <tile/>
    <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
+   <tile gid="5671"/>
+   <tile gid="5671"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1597,7 +1597,7 @@
    <tile/>
    <tile/>
    <tile/>
-   <tile/>
+   <tile gid="5671"/>
    <tile/>
    <tile/>
    <tile/>
@@ -2241,7 +2241,7 @@
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="903" name="Stalwart Rune" type="BuffTile" gid="6607" x="320" y="288" width="32" height="32">
+  <object id="903" name="Stalwart Rune" type="BuffTile" gid="6607" x="544" y="160" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
@@ -2268,75 +2268,57 @@
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="972" name="Piston S" type="Piston" gid="6539" x="448" y="288" width="32" height="32">
-   <properties>
-    <property name="direction" value="SOUTH"/>
-   </properties>
-  </object>
-  <object id="973" name="Piston N" type="Piston" gid="6540" x="352" y="288" width="32" height="32">
-   <properties>
-    <property name="direction" value="NORTH"/>
-   </properties>
-  </object>
-  <object id="974" name="Piston W" type="Piston" gid="6541" x="416" y="320" width="32" height="32">
+  <object id="974" name="Piston W" type="Piston" gid="6541" x="768" y="352" width="32" height="32">
    <properties>
     <property name="direction" value="WEST"/>
    </properties>
   </object>
-  <object id="975" name="Piston E" type="Piston" gid="6542" x="288" y="224" width="32" height="32">
-   <properties>
-    <property name="direction" value="EAST"/>
-   </properties>
-  </object>
-  <object id="976" name="Piston Pad S" type="PressurePlate" gid="6670" x="448" y="224" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston S"/>
-   </properties>
-  </object>
-  <object id="977" name="Piston Pad W" type="PressurePlate" gid="6670" x="448" y="320" width="32" height="32">
+  <object id="977" name="Piston Pad W" type="PressurePlate" gid="6670" x="800" y="352" width="32" height="32">
    <properties>
     <property name="triggerOnRelease" type="bool" value="false"/>
     <property name="triggersId" value="Piston W"/>
    </properties>
   </object>
-  <object id="978" name="Piston Pad N" type="PressurePlate" gid="6670" x="352" y="320" width="32" height="32">
+  <object id="983" name="Launchpad" type="Launchpad" gid="6537" x="768" y="288" width="32" height="32"/>
+  <object id="986" name="Spring Trap" type="SpringTrap" gid="6538" x="704" y="352" width="32" height="32">
    <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston N"/>
+    <property name="trigger.landingCoordinates.x" type="int" value="25"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
    </properties>
   </object>
-  <object id="979" name="Piston Pad E" type="PressurePlate" gid="6670" x="288" y="192" width="32" height="32">
+  <object id="987" name="Jump" type="Crossing" gid="6863" x="384" y="256" width="32" height="32">
    <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston E"/>
+    <property name="direction" value="NONE"/>
    </properties>
   </object>
-  <object id="980" name="Launchpad" type="Launchpad" gid="6537" x="608" y="224" width="32" height="32"/>
-  <object id="981" name="Spring Trap" type="SpringTrap" gid="6538" x="544" y="256" width="32" height="32">
+  <object id="988" name="Jump" type="Crossing" gid="6864" x="320" y="288" width="32" height="32">
    <properties>
-    <property name="trigger.landingCoordinates.x" type="int" value="10"/>
-    <property name="trigger.landingCoordinates.y" type="int" value="8"/>
+    <property name="direction" value="UP"/>
    </properties>
   </object>
-  <object id="982" name="Launchpad" type="Launchpad" gid="6537" x="288" y="256" width="32" height="32"/>
-  <object id="983" name="Launchpad" type="Launchpad" gid="6537" x="544" y="320" width="32" height="32"/>
-  <object id="984" name="Spring Trap" type="SpringTrap" gid="6538" x="480" y="288" width="32" height="32">
+  <object id="989" name="Jump" type="Crossing" gid="6867" x="448" y="320" width="32" height="32">
    <properties>
-    <property name="trigger.landingCoordinates.x" type="int" value="24"/>
-    <property name="trigger.landingCoordinates.y" type="int" value="11"/>
+    <property name="direction" value="LEFT"/>
    </properties>
   </object>
-  <object id="985" name="Spring Trap" type="SpringTrap" gid="6538" x="352" y="224" width="32" height="32">
+  <object id="990" name="Jump" type="Crossing" gid="6866" x="288" y="288" width="32" height="32">
    <properties>
-    <property name="trigger.landingCoordinates.x" type="int" value="14"/>
-    <property name="trigger.landingCoordinates.y" type="int" value="6"/>
+    <property name="direction" value="DOWN"/>
    </properties>
   </object>
-  <object id="986" name="Spring Trap" type="SpringTrap" gid="6538" x="512" y="320" width="32" height="32">
+  <object id="991" name="Jump" type="Crossing" gid="6866" x="544" y="288" width="32" height="32">
    <properties>
-    <property name="trigger.landingCoordinates.x" type="int" value="14"/>
-    <property name="trigger.landingCoordinates.y" type="int" value="9"/>
+    <property name="direction" value="DOWN"/>
+   </properties>
+  </object>
+  <object id="992" name="Jump" type="Crossing" gid="6865" x="448" y="288" width="32" height="32">
+   <properties>
+    <property name="direction" value="RIGHT"/>
+   </properties>
+  </object>
+  <object id="993" name="Jump" type="Crossing" gid="6864" x="576" y="288" width="32" height="32">
+   <properties>
+    <property name="direction" value="UP"/>
    </properties>
   </object>
  </objectgroup>
@@ -2688,7 +2670,7 @@
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="963" name="Orc" type="Creep" gid="23" x="384" y="320" width="32" height="32">
+  <object id="963" name="Orc" type="Creep" gid="23" x="352" y="320" width="32" height="32">
    <properties>
     <property name="Class" value="Orc"/>
     <property name="routine_glutton" type="bool" value="true"/>
@@ -2714,48 +2696,13 @@
     <property name="routine_triggerHappy" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="968" name="Troll" type="Creep" gid="22" x="320" y="224" width="32" height="32">
+  <object id="968" name="Troll" type="Creep" gid="22" x="512" y="320" width="32" height="32">
    <properties>
     <property name="Class" value="Troll"/>
     <property name="Independent" type="bool" value="true"/>
     <property name="routine_defender" type="bool" value="true"/>
     <property name="routine_kingslayer" type="bool" value="true"/>
     <property name="routine_prey" type="bool" value="true"/>
-   </properties>
-  </object>
- </objectgroup>
- <objectgroup id="10" name="Disabled" opacity="0.13">
-  <object id="962" name="Slime" type="Creep" gid="21" x="224" y="320" width="32" height="32">
-   <properties>
-    <property name="Class" value="Slime"/>
-    <property name="routine_glutton" type="bool" value="true"/>
-    <property name="routine_summon" type="bool" value="true"/>
-    <property name="routine_summon.class" value="Slime"/>
-    <property name="routine_treasureHunter" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="965" name="Bat" type="Creep" gid="30" x="192" y="352" width="32" height="32">
-   <properties>
-    <property name="Class" value="Bat"/>
-    <property name="routine_prey" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="966" name="Spider" type="Creep" gid="28" x="224" y="352" width="32" height="32">
-   <properties>
-    <property name="Class" value="Spider"/>
-    <property name="routine_defender" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="969" name="Necromancer" type="Creep" gid="25" x="192" y="320" width="32" height="32">
-   <properties>
-    <property name="Class" value="Necromancer"/>
-    <property name="Commander" type="bool" value="true"/>
-    <property name="fallback_routine" value="routine_wait"/>
-    <property name="routine_defender" type="bool" value="true"/>
-    <property name="routine_kingslayer" type="bool" value="true"/>
-    <property name="routine_prey" type="bool" value="true"/>
-    <property name="routine_summon" type="bool" value="true"/>
-    <property name="routine_summon.class" value="Skeleton"/>
    </properties>
   </object>
   <object id="942" name="Isabella" type="Unit" gid="16" x="480" y="384" width="32" height="32">
@@ -2816,6 +2763,41 @@
    <properties>
     <property name="Class" value="Paladin"/>
     <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="10" name="Disabled" opacity="0.13">
+  <object id="962" name="Slime" type="Creep" gid="21" x="224" y="320" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="965" name="Bat" type="Creep" gid="30" x="192" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Bat"/>
+    <property name="routine_prey" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="966" name="Spider" type="Creep" gid="28" x="224" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Spider"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="969" name="Necromancer" type="Creep" gid="25" x="192" y="320" width="32" height="32">
+   <properties>
+    <property name="Class" value="Necromancer"/>
+    <property name="Commander" type="bool" value="true"/>
+    <property name="fallback_routine" value="routine_wait"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Skeleton"/>
    </properties>
   </object>
  </objectgroup>

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="11" nextobjectid="994">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="11" nextobjectid="999">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -1528,16 +1528,16 @@
    <tile gid="5565"/>
    <tile gid="5567"/>
    <tile/>
+   <tile gid="5712"/>
+   <tile gid="5674"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile gid="5671"/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
    <tile/>
    <tile/>
    <tile/>
@@ -1560,17 +1560,17 @@
    <tile gid="5605"/>
    <tile gid="5607"/>
    <tile/>
-   <tile gid="5671"/>
-   <tile gid="5671"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
-   <tile/>
-   <tile gid="5671"/>
    <tile/>
    <tile/>
    <tile gid="5671"/>
-   <tile gid="5671"/>
    <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5711"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1592,17 +1592,17 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5791"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5671"/>
    <tile/>
    <tile/>
    <tile/>
-   <tile/>
-   <tile/>
+   <tile gid="5672"/>
+   <tile gid="5753"/>
    <tile/>
    <tile/>
    <tile/>
@@ -2286,37 +2286,27 @@
     <property name="trigger.landingCoordinates.y" type="int" value="10"/>
    </properties>
   </object>
-  <object id="987" name="Jump" type="Crossing" gid="6863" x="384" y="256" width="32" height="32">
+  <object id="987" name="Jump" type="Crossing" gid="6863" x="736" y="576" width="32" height="32">
    <properties>
     <property name="direction" value="NONE"/>
    </properties>
   </object>
-  <object id="988" name="Jump" type="Crossing" gid="6864" x="320" y="288" width="32" height="32">
-   <properties>
-    <property name="direction" value="UP"/>
-   </properties>
-  </object>
-  <object id="989" name="Jump" type="Crossing" gid="6867" x="448" y="320" width="32" height="32">
+  <object id="989" name="Jump" type="Crossing" gid="6867" x="832" y="576" width="32" height="32">
    <properties>
     <property name="direction" value="LEFT"/>
    </properties>
   </object>
-  <object id="990" name="Jump" type="Crossing" gid="6866" x="288" y="288" width="32" height="32">
+  <object id="991" name="Jump" type="Crossing" gid="6866" x="800" y="576" width="32" height="32">
    <properties>
     <property name="direction" value="DOWN"/>
    </properties>
   </object>
-  <object id="991" name="Jump" type="Crossing" gid="6866" x="544" y="288" width="32" height="32">
-   <properties>
-    <property name="direction" value="DOWN"/>
-   </properties>
-  </object>
-  <object id="992" name="Jump" type="Crossing" gid="6865" x="448" y="288" width="32" height="32">
+  <object id="992" name="Jump" type="Crossing" gid="6865" x="864" y="576" width="32" height="32">
    <properties>
     <property name="direction" value="RIGHT"/>
    </properties>
   </object>
-  <object id="993" name="Jump" type="Crossing" gid="6864" x="576" y="288" width="32" height="32">
+  <object id="993" name="Jump" type="Crossing" gid="6864" x="768" y="576" width="32" height="32">
    <properties>
     <property name="direction" value="UP"/>
    </properties>

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -2062,14 +2062,14 @@
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="708" name="Pressure Plate" type="PressurePlate" gid="6631" x="576" y="512" width="32" height="32">
+  <object id="708" name="Pressure Plate" type="PressurePlate" gid="6670" x="576" y="512" width="32" height="32">
    <properties>
     <property name="triggerOnRelease" type="bool" value="false"/>
     <property name="triggersId" value="Plate Door"/>
    </properties>
   </object>
   <object id="709" name="Plate Door" type="Door" gid="6571" x="544" y="544" width="32" height="32"/>
-  <object id="710" name="Pressure Plate Double" type="PressurePlate" gid="6653" x="544" y="480" width="32" height="32">
+  <object id="710" name="Pressure Plate Double" type="PressurePlate" gid="6670" x="544" y="480" width="32" height="32">
    <properties>
     <property name="triggersId" value="Plate Door"/>
    </properties>
@@ -2079,7 +2079,7 @@
     <property name="HP" type="int" value="5"/>
    </properties>
   </object>
-  <object id="716" name="Spike Plate" type="PressurePlate" gid="5709" x="800" y="256" width="32" height="32">
+  <object id="716" name="Spike Plate" type="PressurePlate" gid="6670" x="800" y="256" width="32" height="32">
    <properties>
     <property name="triggersId" value="Switch Spike Trap"/>
    </properties>

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="11" nextobjectid="986">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="11" nextobjectid="987">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -2241,7 +2241,7 @@
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="903" name="Stalwart Rune" type="BuffTile" gid="6607" x="544" y="160" width="32" height="32">
+  <object id="903" name="Stalwart Rune" type="BuffTile" gid="6607" x="320" y="288" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
@@ -2268,7 +2268,7 @@
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="972" name="Piston S" type="Piston" gid="6539" x="480" y="256" width="32" height="32">
+  <object id="972" name="Piston S" type="Piston" gid="6539" x="448" y="288" width="32" height="32">
    <properties>
     <property name="direction" value="SOUTH"/>
    </properties>
@@ -2288,13 +2288,13 @@
     <property name="direction" value="EAST"/>
    </properties>
   </object>
-  <object id="976" name="Piston Pad S" type="PressurePlate" gid="6670" x="480" y="224" width="32" height="32">
+  <object id="976" name="Piston Pad S" type="PressurePlate" gid="6670" x="448" y="224" width="32" height="32">
    <properties>
     <property name="triggerOnRelease" type="bool" value="false"/>
     <property name="triggersId" value="Piston S"/>
    </properties>
   </object>
-  <object id="977" name="Piston Pad W" type="PressurePlate" gid="6670" x="448" y="352" width="32" height="32">
+  <object id="977" name="Piston Pad W" type="PressurePlate" gid="6670" x="448" y="320" width="32" height="32">
    <properties>
     <property name="triggerOnRelease" type="bool" value="false"/>
     <property name="triggersId" value="Piston W"/>
@@ -2315,22 +2315,28 @@
   <object id="980" name="Launchpad" type="Launchpad" gid="6537" x="608" y="224" width="32" height="32"/>
   <object id="981" name="Spring Trap" type="SpringTrap" gid="6538" x="544" y="256" width="32" height="32">
    <properties>
-    <property name="trigger.landingCoordinates.x" type="int" value="14"/>
-    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
+    <property name="trigger.landingCoordinates.x" type="int" value="10"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="8"/>
    </properties>
   </object>
   <object id="982" name="Launchpad" type="Launchpad" gid="6537" x="288" y="256" width="32" height="32"/>
   <object id="983" name="Launchpad" type="Launchpad" gid="6537" x="544" y="320" width="32" height="32"/>
-  <object id="984" name="Spring Trap" type="SpringTrap" gid="6538" x="480" y="320" width="32" height="32">
+  <object id="984" name="Spring Trap" type="SpringTrap" gid="6538" x="480" y="288" width="32" height="32">
    <properties>
-    <property name="trigger.landingCoordinates.x" type="int" value="14"/>
-    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
+    <property name="trigger.landingCoordinates.x" type="int" value="24"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="11"/>
    </properties>
   </object>
   <object id="985" name="Spring Trap" type="SpringTrap" gid="6538" x="352" y="224" width="32" height="32">
    <properties>
     <property name="trigger.landingCoordinates.x" type="int" value="14"/>
-    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="6"/>
+   </properties>
+  </object>
+  <object id="986" name="Spring Trap" type="SpringTrap" gid="6538" x="512" y="320" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="14"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="9"/>
    </properties>
   </object>
  </objectgroup>
@@ -2699,7 +2705,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="967" name="Goblin" type="Creep" gid="27" x="448" y="288" width="32" height="32">
+  <object id="967" name="Goblin" type="Creep" gid="27" x="512" y="256" width="32" height="32">
    <properties>
     <property name="Class" value="Goblin"/>
     <property name="routine_basicAttack" type="bool" value="false"/>

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="11" nextobjectid="999">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="11" nextobjectid="1002">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -2592,6 +2592,24 @@
   <object id="917" name="Heart Relic" type="Relic" gid="6455" x="736" y="416" width="32" height="32"/>
   <object id="918" name="Heart Relic" type="Relic" gid="6455" x="768" y="416" width="32" height="32"/>
   <object id="919" name="Heart Relic" type="Relic" gid="6455" x="800" y="416" width="32" height="32"/>
+  <object id="999" name="Free Contract" type="Contract" gid="6471" x="384" y="288" width="32" height="32">
+   <properties>
+    <property name="forSpecificUnit" type="bool" value="false"/>
+    <property name="specificRole" value=""/>
+   </properties>
+  </object>
+  <object id="1000" name="Free Contract" type="Contract" gid="6471" x="416" y="288" width="32" height="32">
+   <properties>
+    <property name="forSpecificUnit" type="bool" value="false"/>
+    <property name="specificRole" value=""/>
+   </properties>
+  </object>
+  <object id="1001" name="Free Contract" type="Contract" gid="6471" x="480" y="288" width="32" height="32">
+   <properties>
+    <property name="forSpecificUnit" type="bool" value="false"/>
+    <property name="specificRole" value=""/>
+   </properties>
+  </object>
  </objectgroup>
  <objectgroup id="8" name="Units">
   <object id="784" name="Slime" type="Creep" gid="21" x="736" y="288" width="32" height="32">

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="10" nextobjectid="980">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="11" nextobjectid="986">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -2273,7 +2273,7 @@
     <property name="direction" value="SOUTH"/>
    </properties>
   </object>
-  <object id="973" name="Piston N" type="Piston" gid="6540" x="512" y="320" width="32" height="32">
+  <object id="973" name="Piston N" type="Piston" gid="6540" x="352" y="288" width="32" height="32">
    <properties>
     <property name="direction" value="NORTH"/>
    </properties>
@@ -2300,16 +2300,37 @@
     <property name="triggersId" value="Piston W"/>
    </properties>
   </object>
-  <object id="978" name="Piston Pad N" type="PressurePlate" gid="6670" x="512" y="352" width="32" height="32">
+  <object id="978" name="Piston Pad N" type="PressurePlate" gid="6670" x="352" y="320" width="32" height="32">
    <properties>
     <property name="triggerOnRelease" type="bool" value="false"/>
     <property name="triggersId" value="Piston N"/>
    </properties>
   </object>
-  <object id="979" name="Piston Pad E" type="PressurePlate" gid="6670" x="544" y="352" width="32" height="32">
+  <object id="979" name="Piston Pad E" type="PressurePlate" gid="6670" x="512" y="320" width="32" height="32">
    <properties>
     <property name="triggerOnRelease" type="bool" value="false"/>
     <property name="triggersId" value="Piston E"/>
+   </properties>
+  </object>
+  <object id="980" name="Launchpad" type="Launchpad" gid="6537" x="320" y="288" width="32" height="32"/>
+  <object id="981" name="Spring Trap" type="SpringTrap" gid="6538" x="544" y="256" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="14"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="982" name="Launchpad" type="Launchpad" gid="6537" x="288" y="288" width="32" height="32"/>
+  <object id="983" name="Launchpad" type="Launchpad" gid="6537" x="416" y="256" width="32" height="32"/>
+  <object id="984" name="Spring Trap" type="SpringTrap" gid="6538" x="480" y="320" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="14"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="985" name="Spring Trap" type="SpringTrap" gid="6538" x="576" y="288" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="14"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
    </properties>
   </object>
  </objectgroup>
@@ -2458,7 +2479,7 @@
   </object>
  </objectgroup>
  <objectgroup id="9" name="Summons" opacity="0.5">
-  <object id="970" name="Slime" type="Creep" gid="21" x="320" y="288" width="32" height="32">
+  <object id="970" name="Slime" type="Creep" gid="21" x="64" y="64" width="32" height="32">
    <properties>
     <property name="Class" value="Slime"/>
     <property name="routine_glutton" type="bool" value="true"/>
@@ -2467,7 +2488,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="971" name="Skeleton" type="Creep" gid="26" x="288" y="288" width="32" height="32">
+  <object id="971" name="Skeleton" type="Creep" gid="26" x="32" y="64" width="32" height="32">
    <properties>
     <property name="Class" value="Skeleton"/>
     <property name="routine_defender" type="bool" value="true"/>
@@ -2721,15 +2742,6 @@
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="962" name="Slime" type="Creep" gid="21" x="320" y="320" width="32" height="32">
-   <properties>
-    <property name="Class" value="Slime"/>
-    <property name="routine_glutton" type="bool" value="true"/>
-    <property name="routine_summon" type="bool" value="true"/>
-    <property name="routine_summon.class" value="Slime"/>
-    <property name="routine_treasureHunter" type="bool" value="true"/>
-   </properties>
-  </object>
   <object id="963" name="Orc" type="Creep" gid="23" x="384" y="320" width="32" height="32">
    <properties>
     <property name="Class" value="Orc"/>
@@ -2747,18 +2759,6 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="965" name="Bat" type="Creep" gid="30" x="512" y="288" width="32" height="32">
-   <properties>
-    <property name="Class" value="Bat"/>
-    <property name="routine_prey" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="966" name="Spider" type="Creep" gid="28" x="544" y="288" width="32" height="32">
-   <properties>
-    <property name="Class" value="Spider"/>
-    <property name="routine_defender" type="bool" value="true"/>
-   </properties>
-  </object>
   <object id="967" name="Goblin" type="Creep" gid="27" x="480" y="288" width="32" height="32">
    <properties>
     <property name="Class" value="Goblin"/>
@@ -2768,7 +2768,7 @@
     <property name="routine_triggerHappy" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="968" name="Troll" type="Creep" gid="22" x="352" y="288" width="32" height="32">
+  <object id="968" name="Troll" type="Creep" gid="22" x="288" y="320" width="32" height="32">
    <properties>
     <property name="Class" value="Troll"/>
     <property name="Independent" type="bool" value="true"/>
@@ -2777,7 +2777,30 @@
     <property name="routine_prey" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="969" name="Necromancer" type="Creep" gid="25" x="288" y="320" width="32" height="32">
+ </objectgroup>
+ <objectgroup id="10" name="Disabled" opacity="0.13">
+  <object id="962" name="Slime" type="Creep" gid="21" x="224" y="320" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="965" name="Bat" type="Creep" gid="30" x="192" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Bat"/>
+    <property name="routine_prey" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="966" name="Spider" type="Creep" gid="28" x="224" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Spider"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="969" name="Necromancer" type="Creep" gid="25" x="192" y="320" width="32" height="32">
    <properties>
     <property name="Class" value="Necromancer"/>
     <property name="Commander" type="bool" value="true"/>

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="10" nextobjectid="972">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="10" nextobjectid="980">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -2268,6 +2268,50 @@
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
+  <object id="972" name="Piston S" type="Piston" gid="6539" x="480" y="256" width="32" height="32">
+   <properties>
+    <property name="direction" value="SOUTH"/>
+   </properties>
+  </object>
+  <object id="973" name="Piston N" type="Piston" gid="6540" x="512" y="320" width="32" height="32">
+   <properties>
+    <property name="direction" value="NORTH"/>
+   </properties>
+  </object>
+  <object id="974" name="Piston W" type="Piston" gid="6541" x="416" y="320" width="32" height="32">
+   <properties>
+    <property name="direction" value="WEST"/>
+   </properties>
+  </object>
+  <object id="975" name="Piston E" type="Piston" gid="6542" x="544" y="320" width="32" height="32">
+   <properties>
+    <property name="direction" value="EAST"/>
+   </properties>
+  </object>
+  <object id="976" name="Piston Pad S" type="PressurePlate" gid="6670" x="448" y="256" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston S"/>
+   </properties>
+  </object>
+  <object id="977" name="Piston Pad W" type="PressurePlate" gid="6670" x="448" y="320" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="978" name="Piston Pad N" type="PressurePlate" gid="6670" x="512" y="352" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston N"/>
+   </properties>
+  </object>
+  <object id="979" name="Piston Pad E" type="PressurePlate" gid="6670" x="544" y="352" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston E"/>
+   </properties>
+  </object>
  </objectgroup>
  <objectgroup id="6" name="Loot" opacity="0.75">
   <object id="748" name="Chest LK1 Key" type="Key" gid="6754" x="864" y="224" width="32" height="32">
@@ -2695,7 +2739,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="964" name="Rat" type="Creep" gid="29" x="576" y="288" width="32" height="32">
+  <object id="964" name="Rat" type="Creep" gid="29" x="576" y="320" width="32" height="32">
    <properties>
     <property name="Class" value="Rat"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
@@ -2724,7 +2768,7 @@
     <property name="routine_triggerHappy" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="968" name="Troll" type="Creep" gid="22" x="352" y="320" width="32" height="32">
+  <object id="968" name="Troll" type="Creep" gid="22" x="352" y="288" width="32" height="32">
    <properties>
     <property name="Class" value="Troll"/>
     <property name="Independent" type="bool" value="true"/>

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -1943,7 +1943,7 @@
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="626" name="Tower Base" type="BuffTile" gid="563" x="448" y="96" width="32" height="32">
+  <object id="626" name="Tower" type="BuffTile" gid="563" x="448" y="96" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
@@ -2045,7 +2045,7 @@
     <property name="destinationId" value="Stairs A1"/>
    </properties>
   </object>
-  <object id="702" name="House" type="BuffTile" gid="6361" x="576" y="96" width="32" height="32">
+  <object id="702" name="Residence" type="BuffTile" gid="6361" x="576" y="96" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
@@ -2057,7 +2057,7 @@
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="706" name="House" type="BuffTile" gid="6368" x="544" y="96" width="32" height="32">
+  <object id="706" name="Residence" type="BuffTile" gid="6368" x="544" y="96" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
@@ -2460,6 +2460,7 @@
   <object id="970" name="Slime" type="Creep" gid="21" x="64" y="64" width="32" height="32">
    <properties>
     <property name="Class" value="Slime"/>
+    <property name="gold" type="int" value="3"/>
     <property name="routine_glutton" type="bool" value="true"/>
     <property name="routine_summon" type="bool" value="true"/>
     <property name="routine_summon.class" value="Slime"/>
@@ -2469,6 +2470,7 @@
   <object id="971" name="Skeleton" type="Creep" gid="26" x="32" y="64" width="32" height="32">
    <properties>
     <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
@@ -2596,6 +2598,7 @@
    <properties>
     <property name="Class" value="Slime"/>
     <property name="Item" value="Chest LK1 Key"/>
+    <property name="gold" type="int" value="3"/>
    </properties>
   </object>
   <object id="944" name="Edward" type="Unit" gid="5" x="512" y="192" width="32" height="32">
@@ -2663,6 +2666,7 @@
   <object id="963" name="Orc" type="Creep" gid="23" x="352" y="320" width="32" height="32">
    <properties>
     <property name="Class" value="Orc"/>
+    <property name="gold" type="int" value="10"/>
     <property name="routine_glutton" type="bool" value="true"/>
     <property name="routine_kingslayer" type="bool" value="true"/>
     <property name="routine_prey" type="bool" value="true"/>
@@ -2672,6 +2676,7 @@
   <object id="964" name="Rat" type="Creep" gid="29" x="352" y="256" width="32" height="32">
    <properties>
     <property name="Class" value="Rat"/>
+    <property name="gold" type="int" value="3"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
     <property name="routine_glutton" type="bool" value="true"/>
     <property name="routine_treasureHunter" type="bool" value="true"/>
@@ -2680,6 +2685,7 @@
   <object id="967" name="Goblin" type="Creep" gid="27" x="512" y="256" width="32" height="32">
    <properties>
     <property name="Class" value="Goblin"/>
+    <property name="gold" type="int" value="8"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
     <property name="routine_glutton" type="bool" value="true"/>
     <property name="routine_prey" type="bool" value="true"/>
@@ -2690,6 +2696,7 @@
    <properties>
     <property name="Class" value="Troll"/>
     <property name="Independent" type="bool" value="true"/>
+    <property name="gold" type="int" value="15"/>
     <property name="routine_defender" type="bool" value="true"/>
     <property name="routine_kingslayer" type="bool" value="true"/>
     <property name="routine_prey" type="bool" value="true"/>
@@ -2760,6 +2767,7 @@
   <object id="962" name="Slime" type="Creep" gid="21" x="224" y="320" width="32" height="32">
    <properties>
     <property name="Class" value="Slime"/>
+    <property name="gold" type="int" value="3"/>
     <property name="routine_glutton" type="bool" value="true"/>
     <property name="routine_summon" type="bool" value="true"/>
     <property name="routine_summon.class" value="Slime"/>
@@ -2769,12 +2777,14 @@
   <object id="965" name="Bat" type="Creep" gid="30" x="192" y="352" width="32" height="32">
    <properties>
     <property name="Class" value="Bat"/>
+    <property name="gold" type="int" value="7"/>
     <property name="routine_prey" type="bool" value="true"/>
    </properties>
   </object>
   <object id="966" name="Spider" type="Creep" gid="28" x="224" y="352" width="32" height="32">
    <properties>
     <property name="Class" value="Spider"/>
+    <property name="gold" type="int" value="5"/>
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
@@ -2783,6 +2793,7 @@
     <property name="Class" value="Necromancer"/>
     <property name="Commander" type="bool" value="true"/>
     <property name="fallback_routine" value="routine_wait"/>
+    <property name="gold" type="int" value="15"/>
     <property name="routine_defender" type="bool" value="true"/>
     <property name="routine_kingslayer" type="bool" value="true"/>
     <property name="routine_prey" type="bool" value="true"/>

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -2076,7 +2076,7 @@
   </object>
   <object id="711" name="Rubble" type="BreakableObstacle" gid="6593" x="416" y="96" width="32" height="32">
    <properties>
-    <property name="HP" type="int" value="5"/>
+    <property name="HP" type="int" value="1"/>
    </properties>
   </object>
   <object id="716" name="Spike Plate" type="PressurePlate" gid="6670" x="800" y="256" width="32" height="32">

--- a/SolStandard/Content/TmxMaps/Debug_01.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_01.tmx
@@ -2283,18 +2283,18 @@
     <property name="direction" value="WEST"/>
    </properties>
   </object>
-  <object id="975" name="Piston E" type="Piston" gid="6542" x="544" y="320" width="32" height="32">
+  <object id="975" name="Piston E" type="Piston" gid="6542" x="288" y="224" width="32" height="32">
    <properties>
     <property name="direction" value="EAST"/>
    </properties>
   </object>
-  <object id="976" name="Piston Pad S" type="PressurePlate" gid="6670" x="448" y="256" width="32" height="32">
+  <object id="976" name="Piston Pad S" type="PressurePlate" gid="6670" x="480" y="224" width="32" height="32">
    <properties>
     <property name="triggerOnRelease" type="bool" value="false"/>
     <property name="triggersId" value="Piston S"/>
    </properties>
   </object>
-  <object id="977" name="Piston Pad W" type="PressurePlate" gid="6670" x="448" y="320" width="32" height="32">
+  <object id="977" name="Piston Pad W" type="PressurePlate" gid="6670" x="448" y="352" width="32" height="32">
    <properties>
     <property name="triggerOnRelease" type="bool" value="false"/>
     <property name="triggersId" value="Piston W"/>
@@ -2306,28 +2306,28 @@
     <property name="triggersId" value="Piston N"/>
    </properties>
   </object>
-  <object id="979" name="Piston Pad E" type="PressurePlate" gid="6670" x="512" y="320" width="32" height="32">
+  <object id="979" name="Piston Pad E" type="PressurePlate" gid="6670" x="288" y="192" width="32" height="32">
    <properties>
     <property name="triggerOnRelease" type="bool" value="false"/>
     <property name="triggersId" value="Piston E"/>
    </properties>
   </object>
-  <object id="980" name="Launchpad" type="Launchpad" gid="6537" x="320" y="288" width="32" height="32"/>
+  <object id="980" name="Launchpad" type="Launchpad" gid="6537" x="608" y="224" width="32" height="32"/>
   <object id="981" name="Spring Trap" type="SpringTrap" gid="6538" x="544" y="256" width="32" height="32">
    <properties>
     <property name="trigger.landingCoordinates.x" type="int" value="14"/>
     <property name="trigger.landingCoordinates.y" type="int" value="10"/>
    </properties>
   </object>
-  <object id="982" name="Launchpad" type="Launchpad" gid="6537" x="288" y="288" width="32" height="32"/>
-  <object id="983" name="Launchpad" type="Launchpad" gid="6537" x="416" y="256" width="32" height="32"/>
+  <object id="982" name="Launchpad" type="Launchpad" gid="6537" x="288" y="256" width="32" height="32"/>
+  <object id="983" name="Launchpad" type="Launchpad" gid="6537" x="544" y="320" width="32" height="32"/>
   <object id="984" name="Spring Trap" type="SpringTrap" gid="6538" x="480" y="320" width="32" height="32">
    <properties>
     <property name="trigger.landingCoordinates.x" type="int" value="14"/>
     <property name="trigger.landingCoordinates.y" type="int" value="10"/>
    </properties>
   </object>
-  <object id="985" name="Spring Trap" type="SpringTrap" gid="6538" x="576" y="288" width="32" height="32">
+  <object id="985" name="Spring Trap" type="SpringTrap" gid="6538" x="352" y="224" width="32" height="32">
    <properties>
     <property name="trigger.landingCoordinates.x" type="int" value="14"/>
     <property name="trigger.landingCoordinates.y" type="int" value="10"/>
@@ -2620,35 +2620,16 @@
     <property name="Item" value="Chest LK1 Key"/>
    </properties>
   </object>
-  <object id="942" name="Isabella" type="Unit" gid="16" x="480" y="384" width="32" height="32">
-   <properties>
-    <property name="Class" value="Pugilist"/>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="943" name="Benjamin" type="Unit" gid="15" x="512" y="384" width="32" height="32">
+  <object id="944" name="Edward" type="Unit" gid="5" x="512" y="192" width="32" height="32">
    <properties>
     <property name="Class" value="Lancer"/>
-    <property name="Commander" type="bool" value="true"/>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="944" name="Edward" type="Unit" gid="5" x="512" y="224" width="32" height="32">
-   <properties>
-    <property name="Class" value="Lancer"/>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="945" name="Isadora" type="Unit" gid="6" x="480" y="224" width="32" height="32">
-   <properties>
-    <property name="Class" value="Pugilist"/>
     <property name="Commander" type="bool" value="true"/>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="946" name="Jules" type="Unit" gid="2" x="352" y="224" width="32" height="32">
+  <object id="945" name="Isadora" type="Unit" gid="6" x="480" y="192" width="32" height="32">
    <properties>
-    <property name="Class" value="Mage"/>
+    <property name="Class" value="Pugilist"/>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
@@ -2664,58 +2645,29 @@
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="949" name="Darwin" type="Unit" gid="9" x="416" y="224" width="32" height="32">
-   <properties>
-    <property name="Class" value="Marauder"/>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="950" name="Gaius" type="Unit" gid="3" x="288" y="224" width="32" height="32">
-   <properties>
-    <property name="Class" value="Champion"/>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
   <object id="951" name="Boyd" type="Unit" gid="13" x="288" y="384" width="32" height="32">
    <properties>
     <property name="Class" value="Champion"/>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="952" name="Fran" type="Unit" gid="4" x="544" y="224" width="32" height="32">
+  <object id="952" name="Fran" type="Unit" gid="4" x="544" y="192" width="32" height="32">
    <properties>
     <property name="Class" value="Bard"/>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="953" name="Benjamin" type="Unit" gid="1" x="320" y="224" width="32" height="32">
-   <properties>
-    <property name="Class" value="Archer"/>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="954" name="Rudolph" type="Unit" gid="7" x="576" y="224" width="32" height="32">
+  <object id="954" name="Rudolph" type="Unit" gid="7" x="576" y="192" width="32" height="32">
    <properties>
     <property name="Class" value="Duelist"/>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="955" name="Maria" type="Unit" gid="18" x="448" y="384" width="32" height="32">
-   <properties>
-    <property name="Class" value="Cleric"/>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
   <object id="956" name="Charlotte" type="Unit" gid="20" x="384" y="384" width="32" height="32">
    <properties>
     <property name="Class" value="Paladin"/>
+    <property name="Commander" type="bool" value="true"/>
     <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="957" name="Rachel" type="Unit" gid="10" x="384" y="224" width="32" height="32">
-   <properties>
-    <property name="Class" value="Paladin"/>
-    <property name="Team" value="Blue"/>
    </properties>
   </object>
   <object id="958" name="Franklin" type="Unit" gid="11" x="320" y="384" width="32" height="32">
@@ -2724,22 +2676,10 @@
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="959" name="Grace" type="Unit" gid="8" x="448" y="224" width="32" height="32">
+  <object id="959" name="Grace" type="Unit" gid="8" x="448" y="192" width="32" height="32">
    <properties>
     <property name="Class" value="Cleric"/>
     <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="960" name="Sally" type="Unit" gid="14" x="544" y="384" width="32" height="32">
-   <properties>
-    <property name="Class" value="Bard"/>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="961" name="Hector" type="Unit" gid="17" x="576" y="384" width="32" height="32">
-   <properties>
-    <property name="Class" value="Duelist"/>
-    <property name="Team" value="Red"/>
    </properties>
   </object>
   <object id="963" name="Orc" type="Creep" gid="23" x="384" y="320" width="32" height="32">
@@ -2751,7 +2691,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="964" name="Rat" type="Creep" gid="29" x="576" y="320" width="32" height="32">
+  <object id="964" name="Rat" type="Creep" gid="29" x="352" y="256" width="32" height="32">
    <properties>
     <property name="Class" value="Rat"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
@@ -2759,7 +2699,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="967" name="Goblin" type="Creep" gid="27" x="480" y="288" width="32" height="32">
+  <object id="967" name="Goblin" type="Creep" gid="27" x="448" y="288" width="32" height="32">
    <properties>
     <property name="Class" value="Goblin"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
@@ -2768,7 +2708,7 @@
     <property name="routine_triggerHappy" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="968" name="Troll" type="Creep" gid="22" x="288" y="320" width="32" height="32">
+  <object id="968" name="Troll" type="Creep" gid="22" x="320" y="224" width="32" height="32">
    <properties>
     <property name="Class" value="Troll"/>
     <property name="Independent" type="bool" value="true"/>
@@ -2810,6 +2750,66 @@
     <property name="routine_prey" type="bool" value="true"/>
     <property name="routine_summon" type="bool" value="true"/>
     <property name="routine_summon.class" value="Skeleton"/>
+   </properties>
+  </object>
+  <object id="942" name="Isabella" type="Unit" gid="16" x="480" y="384" width="32" height="32">
+   <properties>
+    <property name="Class" value="Pugilist"/>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="943" name="Benjamin" type="Unit" gid="15" x="512" y="384" width="32" height="32">
+   <properties>
+    <property name="Class" value="Lancer"/>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="955" name="Maria" type="Unit" gid="18" x="448" y="384" width="32" height="32">
+   <properties>
+    <property name="Class" value="Cleric"/>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="960" name="Sally" type="Unit" gid="14" x="544" y="384" width="32" height="32">
+   <properties>
+    <property name="Class" value="Bard"/>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="961" name="Hector" type="Unit" gid="17" x="576" y="384" width="32" height="32">
+   <properties>
+    <property name="Class" value="Duelist"/>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="946" name="Jules" type="Unit" gid="2" x="352" y="192" width="32" height="32">
+   <properties>
+    <property name="Class" value="Mage"/>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="949" name="Darwin" type="Unit" gid="9" x="416" y="192" width="32" height="32">
+   <properties>
+    <property name="Class" value="Marauder"/>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="950" name="Gaius" type="Unit" gid="3" x="288" y="192" width="32" height="32">
+   <properties>
+    <property name="Class" value="Champion"/>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="953" name="Benjamin" type="Unit" gid="1" x="320" y="192" width="32" height="32">
+   <properties>
+    <property name="Class" value="Archer"/>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="957" name="Rachel" type="Unit" gid="10" x="384" y="192" width="32" height="32">
+   <properties>
+    <property name="Class" value="Paladin"/>
+    <property name="Team" value="Blue"/>
    </properties>
   </object>
  </objectgroup>

--- a/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
@@ -2054,6 +2054,7 @@
   <object id="909" name="Charlotte" type="Unit" gid="20" x="640" y="352" width="32" height="32">
    <properties>
     <property name="Class" value="Paladin"/>
+    <property name="Commander" type="bool" value="true"/>
     <property name="Team" value="Red"/>
    </properties>
   </object>
@@ -2191,7 +2192,7 @@
   <object id="901" name="Eckhart" type="Unit" gid="12" x="576" y="352" width="32" height="32">
    <properties>
     <property name="Class" value="Mage"/>
-    <property name="Commander" type="bool" value="true"/>
+    <property name="Commander" type="bool" value="false"/>
     <property name="Team" value="Red"/>
    </properties>
   </object>

--- a/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="12" nextobjectid="968">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="12" nextobjectid="972">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -1974,6 +1974,7 @@
   <object id="958" name="Slime" type="Creep" gid="21" x="544" y="64" width="32" height="32">
    <properties>
     <property name="Class" value="Slime"/>
+    <property name="gold" type="int" value="5"/>
     <property name="routine_glutton" type="bool" value="true"/>
     <property name="routine_summon" type="bool" value="true"/>
     <property name="routine_summon.class" value="Slime"/>
@@ -1983,38 +1984,39 @@
   <object id="959" name="Skeleton" type="Creep" gid="26" x="512" y="64" width="32" height="32">
    <properties>
     <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
  </objectgroup>
  <objectgroup id="7" name="Items">
-  <object id="926" name="Free Contract" type="Contract" gid="6471" x="352" y="480" width="32" height="32">
+  <object id="926" name="Free Contract" type="Contract" gid="6471" x="576" y="448" width="32" height="32">
    <properties>
     <property name="forSpecificUnit" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="927" name="Healthy Potion" type="HealthPotion" gid="6759" x="640" y="480" width="32" height="32"/>
-  <object id="928" name="Emerald" type="Currency" gid="6784" x="640" y="448" width="32" height="32">
+  <object id="927" name="Healthy Potion" type="HealthPotion" gid="6759" x="608" y="480" width="32" height="32"/>
+  <object id="928" name="Emerald" type="Currency" gid="6784" x="544" y="480" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="929" name="Emerald" type="Currency" gid="6784" x="672" y="416" width="32" height="32">
+  <object id="929" name="Emerald" type="Currency" gid="6784" x="576" y="480" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="930" name="Emerald" type="Currency" gid="6784" x="320" y="320" width="32" height="32">
+  <object id="930" name="Emerald" type="Currency" gid="6784" x="448" y="512" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="931" name="Emerald" type="Currency" gid="6784" x="384" y="448" width="32" height="32">
+  <object id="931" name="Emerald" type="Currency" gid="6784" x="448" y="480" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="932" name="Emerald" type="Currency" gid="6784" x="352" y="384" width="32" height="32">
+  <object id="932" name="Emerald" type="Currency" gid="6784" x="480" y="512" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
@@ -2029,55 +2031,130 @@
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="935" name="Emerald" type="Currency" gid="6784" x="768" y="416" width="32" height="32">
+  <object id="935" name="Emerald" type="Currency" gid="6784" x="576" y="512" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="936" name="Emerald" type="Currency" gid="6784" x="288" y="480" width="32" height="32">
+  <object id="936" name="Emerald" type="Currency" gid="6784" x="416" y="512" width="32" height="32">
    <properties>
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="937" name="Free Contract" type="Contract" gid="6471" x="576" y="416" width="32" height="32">
+  <object id="937" name="Free Contract" type="Contract" gid="6471" x="544" y="448" width="32" height="32">
    <properties>
     <property name="forSpecificUnit" type="bool" value="false"/>
    </properties>
   </object>
-  <object id="938" name="Healthy Potion" type="HealthPotion" gid="6759" x="448" y="416" width="32" height="32"/>
-  <object id="947" name="Healthy Potion" type="HealthPotion" gid="6759" x="672" y="96" width="32" height="32"/>
-  <object id="951" name="Healthy Potion" type="HealthPotion" gid="6759" x="736" y="96" width="32" height="32"/>
+  <object id="938" name="Healthy Potion" type="HealthPotion" gid="6759" x="608" y="512" width="32" height="32"/>
+  <object id="947" name="Healthy Potion" type="HealthPotion" gid="6759" x="448" y="448" width="32" height="32"/>
+  <object id="951" name="Healthy Potion" type="HealthPotion" gid="6759" x="480" y="448" width="32" height="32"/>
  </objectgroup>
  <objectgroup id="8" name="Units">
-  <object id="901" name="Eckhart" type="Unit" gid="12" x="416" y="352" width="32" height="32">
+  <object id="901" name="Eckhart" type="Unit" gid="12" x="576" y="352" width="32" height="32">
    <properties>
     <property name="Class" value="Mage"/>
     <property name="Commander" type="bool" value="true"/>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="907" name="Maria" type="Unit" gid="18" x="448" y="352" width="32" height="32">
+  <object id="907" name="Maria" type="Unit" gid="16" x="608" y="352" width="32" height="32">
    <properties>
-    <property name="Class" value="Cleric"/>
+    <property name="Class" value="Pugilist"/>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="909" name="Charlotte" type="Unit" gid="20" x="480" y="352" width="32" height="32">
+  <object id="909" name="Charlotte" type="Unit" gid="20" x="640" y="352" width="32" height="32">
    <properties>
     <property name="Class" value="Paladin"/>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="960" name="Slime" type="Creep" gid="21" x="512" y="192" width="32" height="32">
+  <object id="960" name="Slime" type="Creep" gid="21" x="736" y="320" width="32" height="32">
    <properties>
     <property name="Class" value="Slime"/>
+    <property name="gold" type="int" value="3"/>
     <property name="routine_glutton" type="bool" value="true"/>
     <property name="routine_summon" type="bool" value="true"/>
     <property name="routine_summon.class" value="Slime"/>
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="961" name="Orc" type="Creep" gid="23" x="576" y="192" width="32" height="32">
+  <object id="967" name="Necromancer" type="Creep" gid="25" x="736" y="224" width="32" height="32">
+   <properties>
+    <property name="Class" value="Necromancer"/>
+    <property name="Commander" type="bool" value="true"/>
+    <property name="fallback_routine" value="routine_wait"/>
+    <property name="gold" type="int" value="16"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Skeleton"/>
+   </properties>
+  </object>
+  <object id="903" name="Ethan" type="Unit" gid="5" x="704" y="448" width="32" height="32">
+   <properties>
+    <property name="Class" value="Lancer"/>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="904" name="Qorf" type="Unit" gid="1" x="672" y="448" width="32" height="32">
+   <properties>
+    <property name="Class" value="Archer"/>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="902" name="Gaius" type="Unit" gid="3" x="640" y="448" width="32" height="32">
+   <properties>
+    <property name="Class" value="Champion"/>
+    <property name="Commander" type="bool" value="true"/>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="968" name="Slime" type="Creep" gid="21" x="672" y="288" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="gold" type="int" value="3"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="969" name="Slime" type="Creep" gid="21" x="736" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="gold" type="int" value="3"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="970" name="Slime" type="Creep" gid="21" x="640" y="256" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="gold" type="int" value="3"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="971" name="Slime" type="Creep" gid="21" x="736" y="384" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="gold" type="int" value="3"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="9" name="Disabled" opacity="0.24">
+  <object id="961" name="Orc" type="Creep" gid="23" x="480" y="96" width="32" height="32">
    <properties>
     <property name="Class" value="Orc"/>
     <property name="routine_glutton" type="bool" value="true"/>
@@ -2086,7 +2163,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="962" name="Rat" type="Creep" gid="29" x="704" y="192" width="32" height="32">
+  <object id="962" name="Rat" type="Creep" gid="29" x="608" y="96" width="32" height="32">
    <properties>
     <property name="Class" value="Rat"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
@@ -2094,19 +2171,19 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="963" name="Bat" type="Creep" gid="30" x="640" y="192" width="32" height="32">
+  <object id="963" name="Bat" type="Creep" gid="30" x="544" y="96" width="32" height="32">
    <properties>
     <property name="Class" value="Bat"/>
     <property name="routine_prey" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="964" name="Spider" type="Creep" gid="28" x="672" y="192" width="32" height="32">
+  <object id="964" name="Spider" type="Creep" gid="28" x="576" y="96" width="32" height="32">
    <properties>
     <property name="Class" value="Spider"/>
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="965" name="Goblin" type="Creep" gid="27" x="608" y="192" width="32" height="32">
+  <object id="965" name="Goblin" type="Creep" gid="27" x="512" y="96" width="32" height="32">
    <properties>
     <property name="Class" value="Goblin"/>
     <property name="routine_basicAttack" type="bool" value="false"/>
@@ -2115,46 +2192,13 @@
     <property name="routine_triggerHappy" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="966" name="Troll" type="Creep" gid="22" x="544" y="192" width="32" height="32">
+  <object id="966" name="Troll" type="Creep" gid="22" x="448" y="96" width="32" height="32">
    <properties>
     <property name="Class" value="Troll"/>
     <property name="Independent" type="bool" value="true"/>
     <property name="routine_defender" type="bool" value="true"/>
     <property name="routine_kingslayer" type="bool" value="true"/>
     <property name="routine_prey" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="967" name="Necromancer" type="Creep" gid="25" x="480" y="192" width="32" height="32">
-   <properties>
-    <property name="Class" value="Necromancer"/>
-    <property name="Commander" type="bool" value="true"/>
-    <property name="fallback_routine" value="routine_wait"/>
-    <property name="routine_defender" type="bool" value="true"/>
-    <property name="routine_kingslayer" type="bool" value="true"/>
-    <property name="routine_prey" type="bool" value="true"/>
-    <property name="routine_summon" type="bool" value="true"/>
-    <property name="routine_summon.class" value="Skeleton"/>
-   </properties>
-  </object>
- </objectgroup>
- <objectgroup id="9" name="Disabled" opacity="0.24">
-  <object id="903" name="Ethan" type="Unit" gid="5" x="608" y="352" width="32" height="32">
-   <properties>
-    <property name="Class" value="Lancer"/>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="904" name="Qorf" type="Unit" gid="1" x="576" y="352" width="32" height="32">
-   <properties>
-    <property name="Class" value="Archer"/>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="902" name="Gaius" type="Unit" gid="3" x="544" y="352" width="32" height="32">
-   <properties>
-    <property name="Class" value="Champion"/>
-    <property name="Commander" type="bool" value="true"/>
-    <property name="Team" value="Blue"/>
    </properties>
   </object>
  </objectgroup>

--- a/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="12" nextobjectid="972">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="12" nextobjectid="974">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -1990,7 +1990,7 @@
   </object>
  </objectgroup>
  <objectgroup id="7" name="Items">
-  <object id="926" name="Free Contract" type="Contract" gid="6471" x="576" y="448" width="32" height="32">
+  <object id="926" name="Free Contract" type="Contract" gid="6471" x="608" y="416" width="32" height="32">
    <properties>
     <property name="forSpecificUnit" type="bool" value="false"/>
    </properties>
@@ -2041,7 +2041,7 @@
     <property name="value" type="int" value="10"/>
    </properties>
   </object>
-  <object id="937" name="Free Contract" type="Contract" gid="6471" x="544" y="448" width="32" height="32">
+  <object id="937" name="Free Contract" type="Contract" gid="6471" x="608" y="384" width="32" height="32">
    <properties>
     <property name="forSpecificUnit" type="bool" value="false"/>
    </properties>
@@ -2049,6 +2049,16 @@
   <object id="938" name="Healthy Potion" type="HealthPotion" gid="6759" x="608" y="512" width="32" height="32"/>
   <object id="947" name="Healthy Potion" type="HealthPotion" gid="6759" x="448" y="448" width="32" height="32"/>
   <object id="951" name="Healthy Potion" type="HealthPotion" gid="6759" x="480" y="448" width="32" height="32"/>
+  <object id="972" name="Free Contract" type="Contract" gid="6471" x="672" y="384" width="32" height="32">
+   <properties>
+    <property name="forSpecificUnit" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="973" name="Free Contract" type="Contract" gid="6471" x="672" y="416" width="32" height="32">
+   <properties>
+    <property name="forSpecificUnit" type="bool" value="false"/>
+   </properties>
+  </object>
  </objectgroup>
  <objectgroup id="8" name="Units">
   <object id="909" name="Charlotte" type="Unit" gid="20" x="640" y="352" width="32" height="32">

--- a/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
+++ b/SolStandard/Content/TmxMaps/Debug_03_AI.tmx
@@ -2051,19 +2051,6 @@
   <object id="951" name="Healthy Potion" type="HealthPotion" gid="6759" x="480" y="448" width="32" height="32"/>
  </objectgroup>
  <objectgroup id="8" name="Units">
-  <object id="901" name="Eckhart" type="Unit" gid="12" x="576" y="352" width="32" height="32">
-   <properties>
-    <property name="Class" value="Mage"/>
-    <property name="Commander" type="bool" value="true"/>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="907" name="Maria" type="Unit" gid="16" x="608" y="352" width="32" height="32">
-   <properties>
-    <property name="Class" value="Pugilist"/>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
   <object id="909" name="Charlotte" type="Unit" gid="20" x="640" y="352" width="32" height="32">
    <properties>
     <property name="Class" value="Paladin"/>
@@ -2091,18 +2078,6 @@
     <property name="routine_prey" type="bool" value="true"/>
     <property name="routine_summon" type="bool" value="true"/>
     <property name="routine_summon.class" value="Skeleton"/>
-   </properties>
-  </object>
-  <object id="903" name="Ethan" type="Unit" gid="5" x="704" y="448" width="32" height="32">
-   <properties>
-    <property name="Class" value="Lancer"/>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="904" name="Qorf" type="Unit" gid="1" x="672" y="448" width="32" height="32">
-   <properties>
-    <property name="Class" value="Archer"/>
-    <property name="Team" value="Blue"/>
    </properties>
   </object>
   <object id="902" name="Gaius" type="Unit" gid="3" x="640" y="448" width="32" height="32">
@@ -2199,6 +2174,31 @@
     <property name="routine_defender" type="bool" value="true"/>
     <property name="routine_kingslayer" type="bool" value="true"/>
     <property name="routine_prey" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="903" name="Ethan" type="Unit" gid="5" x="704" y="448" width="32" height="32">
+   <properties>
+    <property name="Class" value="Lancer"/>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="904" name="Qorf" type="Unit" gid="1" x="672" y="448" width="32" height="32">
+   <properties>
+    <property name="Class" value="Archer"/>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="901" name="Eckhart" type="Unit" gid="12" x="576" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Mage"/>
+    <property name="Commander" type="bool" value="true"/>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="907" name="Maria" type="Unit" gid="16" x="608" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Pugilist"/>
+    <property name="Team" value="Red"/>
    </properties>
   </object>
  </objectgroup>

--- a/SolStandard/Content/TmxMaps/Draft_Factory_Floor.tmx
+++ b/SolStandard/Content/TmxMaps/Draft_Factory_Floor.tmx
@@ -1,0 +1,3591 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="12" nextobjectid="1181">
+ <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
+  <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
+ </tileset>
+ <tileset firstgid="31" source="overworld-32.tsx"/>
+ <tileset firstgid="6311" source="entities-32.tsx"/>
+ <layer id="1" name="Terrain" width="32" height="20">
+  <data>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+  </data>
+ </layer>
+ <layer id="2" name="TerrainDecoration" width="32" height="20">
+  <data>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+  </data>
+ </layer>
+ <layer id="3" name="Collide" width="32" height="20">
+  <data>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5406"/>
+  </data>
+ </layer>
+ <objectgroup id="5" name="Entities">
+  <object id="983" name="Piston W" type="Piston" gid="6541" x="352" y="192" width="32" height="32">
+   <properties>
+    <property name="direction" value="WEST"/>
+   </properties>
+  </object>
+  <object id="984" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="128" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="985" name="Launchpad" type="Launchpad" gid="6537" x="320" y="256" width="32" height="32"/>
+  <object id="986" name="Spring Trap" type="SpringTrap" gid="6538" x="608" y="512" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="25"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="988" name="Bridge Chest" type="Chest" gid="6544" x="192" y="416" width="32" height="32">
+   <properties>
+    <property name="item" value="DeployBridge"/>
+   </properties>
+  </object>
+  <object id="989" name="Magic Trap" type="Trap" gid="6755" x="352" y="320" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="990" name="Spike Trap" type="Trap" gid="5911" x="288" y="192" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="992" name="Power Rune" type="BuffTile" gid="6611" x="256" y="544" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="993" name="Counter Rune" type="BuffTile" gid="6619" x="416" y="320" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="994" name="Fortune Rune" type="BuffTile" gid="6615" x="416" y="192" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="995" name="Stalwart Rune" type="BuffTile" gid="6607" x="224" y="576" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="959" name="Deploy Blue" type="Deployment" gid="6342" x="672" y="128" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="960" name="Deploy Red" type="Deployment" gid="6350" x="96" y="512" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="973" name="Deploy Blue" type="Deployment" gid="6342" x="704" y="128" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="974" name="Deploy Blue" type="Deployment" gid="6342" x="768" y="128" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="975" name="Deploy Red" type="Deployment" gid="6350" x="128" y="480" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="976" name="Deploy Red" type="Deployment" gid="6350" x="160" y="512" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="977" name="Deploy Red" type="Deployment" gid="6350" x="128" y="544" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="978" name="Deploy Red" type="Deployment" gid="6350" x="96" y="448" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="979" name="Deploy Red" type="Deployment" gid="6350" x="64" y="480" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="980" name="Deploy Blue" type="Deployment" gid="6342" x="672" y="96" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="981" name="Deploy Blue" type="Deployment" gid="6342" x="736" y="96" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="982" name="Deploy Blue" type="Deployment" gid="6342" x="768" y="96" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="997" name="Switch E" type="Switch" gid="6597" x="736" y="512" width="32" height="32">
+   <properties>
+    <property name="triggersId" value="Switch Door E"/>
+   </properties>
+  </object>
+  <object id="998" name="Switch Door E" type="Door" gid="6565" x="640" y="288" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1000" name="Unlocked Door" type="Door" gid="6579" x="736" y="448" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1002" name="Opened Door" type="Door" gid="2147490227" x="864" y="224" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+    <property name="isOpen" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1003" name="Opened Door" type="Door" gid="2147490227" x="864" y="192" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+    <property name="isOpen" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1004" name="Unlocked Door" type="Door" gid="6579" x="768" y="448" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1005" name="Switch Door E" type="Door" gid="6565" x="640" y="320" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1008" name="Opened Door" type="Door" gid="2147490227" x="160" y="192" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+    <property name="isOpen" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1009" name="Opened Door" type="Door" gid="2147490227" x="160" y="160" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+    <property name="isOpen" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1012" name="Spring Trap" type="SpringTrap" gid="6538" x="416" y="512" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="25"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1013" name="Spring Trap" type="SpringTrap" gid="6538" x="416" y="544" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="25"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1014" name="Spring Trap" type="SpringTrap" gid="6538" x="608" y="544" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="25"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1015" name="Unlocked Door" type="Door" gid="6579" x="64" y="288" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1016" name="Unlocked Door" type="Door" gid="6579" x="96" y="288" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1017" name="Switch Door S" type="Door" gid="6565" x="352" y="448" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1018" name="Switch Door S" type="Door" gid="6565" x="320" y="448" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1019" name="Switch S" type="Switch" gid="6597" x="96" y="192" width="32" height="32">
+   <properties>
+    <property name="triggersId" value="Switch Door S"/>
+   </properties>
+  </object>
+  <object id="1020" name="Spike Trap" type="Trap" gid="5911" x="352" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1021" name="Spike Trap" type="Trap" gid="5911" x="256" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1022" name="Spike Trap" type="Trap" gid="5911" x="320" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1023" name="Spike Trap" type="Trap" gid="5911" x="256" y="352" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1025" name="Spike Trap" type="Trap" gid="5911" x="288" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1026" name="Spike Trap" type="Trap" gid="5911" x="288" y="224" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1028" name="Spike Trap" type="Trap" gid="5911" x="384" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1029" name="Spike Trap" type="Trap" gid="5911" x="224" y="416" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1030" name="Spike Trap" type="Trap" gid="5911" x="448" y="448" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1031" name="Spike Trap" type="Trap" gid="5911" x="352" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1032" name="Spike Trap" type="Trap" gid="5911" x="352" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1033" name="Spike Trap" type="Trap" gid="5911" x="384" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1034" name="Spike Trap" type="Trap" gid="5911" x="448" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1036" name="Spike Trap" type="Trap" gid="5911" x="224" y="96" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1037" name="Spike Trap" type="Trap" gid="5911" x="192" y="224" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1038" name="Spike Trap" type="Trap" gid="5911" x="416" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1039" name="Spike Trap" type="Trap" gid="5911" x="384" y="160" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1040" name="Spike Trap" type="Trap" gid="5911" x="384" y="192" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1041" name="Spike Trap" type="Trap" gid="5911" x="384" y="224" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1043" name="Spike Trap" type="Trap" gid="5911" x="192" y="96" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1044" name="Spike Trap" type="Trap" gid="5911" x="192" y="128" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1045" name="Spike Trap" type="Trap" gid="5911" x="256" y="96" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1047" name="Spike Trap" type="Trap" gid="5911" x="896" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1048" name="Spike Trap" type="Trap" gid="5911" x="928" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1049" name="Spike Trap" type="Trap" gid="5911" x="960" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1050" name="Spike Trap" type="Trap" gid="5911" x="896" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1051" name="Spike Trap" type="Trap" gid="5911" x="928" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1052" name="Spike Trap" type="Trap" gid="5911" x="960" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1053" name="Spike Trap" type="Trap" gid="5911" x="896" y="320" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1054" name="Spike Trap" type="Trap" gid="5911" x="928" y="320" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1055" name="Spike Trap" type="Trap" gid="5911" x="960" y="320" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1056" name="Spike Trap" type="Trap" gid="5911" x="896" y="352" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1057" name="Spike Trap" type="Trap" gid="5911" x="928" y="352" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1058" name="Spike Trap" type="Trap" gid="5911" x="960" y="352" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1059" name="Spike Trap" type="Trap" gid="5911" x="896" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1060" name="Spike Trap" type="Trap" gid="5911" x="928" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1061" name="Spike Trap" type="Trap" gid="5911" x="960" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1062" name="Spike Trap" type="Trap" gid="5911" x="896" y="416" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1063" name="Spike Trap" type="Trap" gid="5911" x="928" y="416" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1064" name="Spike Trap" type="Trap" gid="5911" x="960" y="416" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1065" name="Spike Trap" type="Trap" gid="5911" x="896" y="448" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1066" name="Spike Trap" type="Trap" gid="5911" x="928" y="448" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1067" name="Spike Trap" type="Trap" gid="5911" x="960" y="448" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1068" name="Spike Trap" type="Trap" gid="5911" x="896" y="480" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1069" name="Spike Trap" type="Trap" gid="5911" x="928" y="480" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1070" name="Spike Trap" type="Trap" gid="5911" x="960" y="480" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1071" name="Spike Trap" type="Trap" gid="5911" x="32" y="352" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1072" name="Spike Trap" type="Trap" gid="5911" x="64" y="352" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1073" name="Spike Trap" type="Trap" gid="5911" x="96" y="352" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1074" name="Spike Trap" type="Trap" gid="5911" x="32" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1075" name="Spike Trap" type="Trap" gid="5911" x="64" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1076" name="Spike Trap" type="Trap" gid="5911" x="96" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1077" name="Spike Trap" type="Trap" gid="5911" x="128" y="352" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1078" name="Spike Trap" type="Trap" gid="5911" x="128" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1079" name="Spike Trap" type="Trap" gid="5911" x="32" y="320" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1080" name="Spike Trap" type="Trap" gid="5911" x="64" y="320" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1081" name="Spike Trap" type="Trap" gid="5911" x="96" y="320" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1082" name="Spike Trap" type="Trap" gid="5911" x="128" y="320" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1083" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="160" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1084" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="192" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1085" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="224" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1086" name="Piston Pad W" type="PressurePlate" gid="6670" x="256" y="224" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1087" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="320" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1088" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="288" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1089" name="Piston Pad W" type="PressurePlate" gid="6670" x="256" y="256" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1090" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="320" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1091" name="Piston Pad W" type="PressurePlate" gid="6670" x="288" y="384" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1092" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="384" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1093" name="Piston Pad W" type="PressurePlate" gid="6670" x="256" y="384" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1094" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="352" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1095" name="Piston Pad W" type="PressurePlate" gid="6670" x="288" y="352" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1096" name="Piston Pad W" type="PressurePlate" gid="6670" x="288" y="416" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1097" name="Piston Pad W" type="PressurePlate" gid="6670" x="288" y="320" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1098" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="288" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1099" name="Piston Pad W" type="PressurePlate" gid="6670" x="256" y="128" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1100" name="Piston Pad W" type="PressurePlate" gid="6670" x="288" y="128" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1101" name="Piston Pad W" type="PressurePlate" gid="6670" x="352" y="128" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1102" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="160" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1103" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="128" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1114" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="224" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1115" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="192" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1116" name="Piston W" type="Piston" gid="6541" x="352" y="224" width="32" height="32">
+   <properties>
+    <property name="direction" value="WEST"/>
+   </properties>
+  </object>
+  <object id="1117" name="Piston E" type="Piston" gid="6542" x="192" y="288" width="32" height="32">
+   <properties>
+    <property name="direction" value="EAST"/>
+   </properties>
+  </object>
+  <object id="1118" name="Piston E" type="Piston" gid="6542" x="192" y="320" width="32" height="32">
+   <properties>
+    <property name="direction" value="EAST"/>
+   </properties>
+  </object>
+  <object id="1119" name="Piston E" type="Piston" gid="6542" x="192" y="352" width="32" height="32">
+   <properties>
+    <property name="direction" value="EAST"/>
+   </properties>
+  </object>
+  <object id="1120" name="Piston E" type="Piston" gid="6542" x="192" y="384" width="32" height="32">
+   <properties>
+    <property name="direction" value="EAST"/>
+   </properties>
+  </object>
+  <object id="1122" name="Spike Trap" type="Trap" gid="5911" x="384" y="416" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1123" name="Piston N" type="Piston" gid="6540" x="320" y="352" width="32" height="32">
+   <properties>
+    <property name="direction" value="NORTH"/>
+   </properties>
+  </object>
+  <object id="1124" name="Piston N" type="Piston" gid="6540" x="256" y="160" width="32" height="32">
+   <properties>
+    <property name="direction" value="NORTH"/>
+   </properties>
+  </object>
+  <object id="1126" name="Piston E" type="Piston" gid="6542" x="288" y="288" width="32" height="32">
+   <properties>
+    <property name="direction" value="EAST"/>
+   </properties>
+  </object>
+  <object id="1127" name="Piston N" type="Piston" gid="6540" x="256" y="416" width="32" height="32">
+   <properties>
+    <property name="direction" value="NORTH"/>
+   </properties>
+  </object>
+  <object id="1128" name="Launchpad" type="Launchpad" gid="6537" x="352" y="160" width="32" height="32"/>
+  <object id="1129" name="Launchpad" type="Launchpad" gid="6537" x="352" y="352" width="32" height="32"/>
+  <object id="1130" name="Piston E" type="Piston" gid="6542" x="224" y="256" width="32" height="32">
+   <properties>
+    <property name="direction" value="EAST"/>
+   </properties>
+  </object>
+  <object id="1131" name="Piston S" type="Piston" gid="6539" x="256" y="192" width="32" height="32">
+   <properties>
+    <property name="direction" value="SOUTH"/>
+   </properties>
+  </object>
+  <object id="1132" name="Spike Trap" type="Trap" gid="5911" x="480" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1133" name="Spike Trap" type="Trap" gid="5911" x="480" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1134" name="Spike Trap" type="Trap" gid="5911" x="416" y="416" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1135" name="Spike Trap" type="Trap" gid="5911" x="448" y="416" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1138" name="Spike Trap" type="Trap" gid="5911" x="384" y="96" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1139" name="Spike Trap" type="Trap" gid="5911" x="416" y="96" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1145" name="Magic Trap" type="Trap" gid="6755" x="384" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1146" name="Piston Pad W" type="PressurePlate" gid="6670" x="384" y="128" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1147" name="Magic Trap" type="Trap" gid="6755" x="288" y="160" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1148" name="Magic Trap" type="Trap" gid="6755" x="288" y="96" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1149" name="Magic Trap" type="Trap" gid="6755" x="320" y="96" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1150" name="Magic Trap" type="Trap" gid="6755" x="352" y="96" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1151" name="Magic Trap" type="Trap" gid="6755" x="256" y="320" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1152" name="Power Rune" type="BuffTile" gid="6611" x="544" y="256" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1153" name="Counter Rune" type="BuffTile" gid="6619" x="256" y="512" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1154" name="Fortune Rune" type="BuffTile" gid="6615" x="480" y="352" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1155" name="Stalwart Rune" type="BuffTile" gid="6607" x="704" y="384" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1156" name="Power Rune" type="BuffTile" gid="6611" x="480" y="416" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1157" name="Counter Rune" type="BuffTile" gid="6619" x="544" y="384" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1158" name="Fortune Rune" type="BuffTile" gid="6615" x="576" y="320" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1160" name="Fortune Rune" type="BuffTile" gid="6615" x="224" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1162" name="Power Rune" type="BuffTile" gid="6611" x="672" y="512" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1163" name="Stalwart Rune" type="BuffTile" gid="6607" x="704" y="576" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1164" name="Counter Rune" type="BuffTile" gid="6619" x="672" y="544" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1165" name="Fortune Rune" type="BuffTile" gid="6615" x="704" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1166" name="Bridge Chest" type="Chest" gid="6544" x="736" y="320" width="32" height="32">
+   <properties>
+    <property name="item" value="DeployBridge"/>
+   </properties>
+  </object>
+  <object id="1167" name="Bridge Chest" type="Chest" gid="6544" x="96" y="96" width="32" height="32">
+   <properties>
+    <property name="item" value="DeployBridge"/>
+   </properties>
+  </object>
+  <object id="1168" name="Power Rune" type="BuffTile" gid="6611" x="64" y="192" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1170" name="Counter Rune" type="BuffTile" gid="6619" x="96" y="160" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1171" name="Fortune Rune" type="BuffTile" gid="6615" x="96" y="224" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1172" name="Power Rune" type="BuffTile" gid="6611" x="512" y="128" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1173" name="Counter Rune" type="BuffTile" gid="6619" x="512" y="96" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1174" name="Fortune Rune" type="BuffTile" gid="6615" x="512" y="160" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1175" name="Rubble" type="BreakableObstacle" gid="6593" x="512" y="320" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1176" name="Rubble" type="BreakableObstacle" gid="6593" x="544" y="352" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1177" name="Rubble" type="BreakableObstacle" gid="6593" x="512" y="384" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1178" name="Rubble" type="BreakableObstacle" gid="6593" x="512" y="352" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1179" name="Switch Door E" type="Door" gid="6565" x="672" y="256" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1180" name="Switch Door E" type="Door" gid="6565" x="704" y="256" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="6" name="Loot" opacity="0.58">
+  <object id="987" name="DeployBridge" type="LadderBridge" gid="6662" x="160" y="416" width="32" height="32"/>
+ </objectgroup>
+ <objectgroup id="11" name="Summons" opacity="0.69">
+  <object id="961" name="Slime" type="Creep" gid="21" x="32" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="971" name="Skeleton" type="Creep" gid="26" x="0" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="7" name="Items">
+  <object id="991" name="Arcane Flint [R]" type="RecallCharm" gid="6809" x="928" y="320" width="32" height="32">
+   <properties>
+    <property name="recallId" value="Return Point [R]"/>
+   </properties>
+  </object>
+  <object id="996" name="Magnet" type="Magnet" gid="6826" x="320" y="96" width="32" height="32"/>
+  <object id="1141" name="Arcane Flint [K]" type="RecallCharm" gid="6809" x="288" y="160" width="32" height="32">
+   <properties>
+    <property name="recallId" value="Return Point [K]"/>
+   </properties>
+  </object>
+  <object id="1142" name="Magnet" type="Magnet" gid="6826" x="384" y="256" width="32" height="32"/>
+  <object id="1143" name="Magnet" type="Magnet" gid="6826" x="256" y="320" width="32" height="32"/>
+  <object id="1144" name="Magnet" type="Magnet" gid="6826" x="928" y="416" width="32" height="32"/>
+ </objectgroup>
+ <objectgroup id="8" name="Units"/>
+ <objectgroup id="9" name="Disabled" opacity="0.43">
+  <object id="963" name="Slime" type="Creep" gid="21" x="544" y="576" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="965" name="Orc" type="Creep" gid="23" x="512" y="512" width="32" height="32">
+   <properties>
+    <property name="Class" value="Orc"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="966" name="Rat" type="Creep" gid="29" x="576" y="608" width="32" height="32">
+   <properties>
+    <property name="Class" value="Rat"/>
+    <property name="routine_basicAttack" type="bool" value="false"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="967" name="Bat" type="Creep" gid="30" x="544" y="608" width="32" height="32">
+   <properties>
+    <property name="Class" value="Bat"/>
+    <property name="routine_prey" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="968" name="Spider" type="Creep" gid="28" x="480" y="608" width="32" height="32">
+   <properties>
+    <property name="Class" value="Spider"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="969" name="Goblin" type="Creep" gid="27" x="512" y="576" width="32" height="32">
+   <properties>
+    <property name="Class" value="Goblin"/>
+    <property name="routine_basicAttack" type="bool" value="false"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_triggerHappy" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="970" name="Troll" type="Creep" gid="22" x="448" y="544" width="32" height="32">
+   <properties>
+    <property name="Class" value="Troll"/>
+    <property name="Independent" type="bool" value="true"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="972" name="Necromancer" type="Creep" gid="25" x="544" y="512" width="32" height="32">
+   <properties>
+    <property name="Class" value="Necromancer"/>
+    <property name="Commander" type="bool" value="true"/>
+    <property name="fallback_routine" value="routine_wait"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Skeleton"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <layer id="4" name="Overlay" width="32" height="20">
+  <data>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+  </data>
+ </layer>
+</map>

--- a/SolStandard/Content/TmxMaps/Draft_Factory_Floor.tmx
+++ b/SolStandard/Content/TmxMaps/Draft_Factory_Floor.tmx
@@ -1,655 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="12" nextobjectid="1181">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="34" height="21" tilewidth="32" tileheight="32" infinite="0" nextlayerid="20" nextobjectid="1394">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
  <tileset firstgid="31" source="overworld-32.tsx"/>
  <tileset firstgid="6311" source="entities-32.tsx"/>
- <layer id="1" name="Terrain" width="32" height="20">
-  <data>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-   <tile gid="5351"/>
-  </data>
- </layer>
- <layer id="2" name="TerrainDecoration" width="32" height="20">
+ <layer id="16" name="Terrain" width="34" height="21">
   <data>
    <tile/>
    <tile/>
@@ -686,614 +42,1406 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5686"/>
+   <tile gid="5685"/>
+   <tile gid="5686"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5685"/>
+   <tile gid="5686"/>
+   <tile gid="5685"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5502"/>
+   <tile gid="5503"/>
+   <tile gid="5503"/>
+   <tile gid="5503"/>
+   <tile gid="5503"/>
+   <tile gid="5504"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5520"/>
+   <tile gid="5521"/>
+   <tile gid="5522"/>
+   <tile gid="5683"/>
+   <tile gid="5684"/>
+   <tile gid="5351"/>
+   <tile gid="5355"/>
+   <tile gid="5357"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5686"/>
+   <tile gid="5685"/>
+   <tile gid="5686"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5502"/>
+   <tile gid="5546"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5544"/>
+   <tile gid="5351"/>
+   <tile gid="5382"/>
+   <tile gid="5383"/>
+   <tile gid="5384"/>
+   <tile gid="5351"/>
+   <tile/>
    <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5560"/>
+   <tile gid="5561"/>
+   <tile gid="5562"/>
+   <tile gid="5723"/>
+   <tile gid="5724"/>
+   <tile gid="5355"/>
+   <tile gid="5358"/>
+   <tile gid="5397"/>
+   <tile gid="5355"/>
+   <tile gid="5357"/>
+   <tile gid="5355"/>
+   <tile gid="5356"/>
+   <tile gid="5357"/>
+   <tile gid="5351"/>
+   <tile gid="5685"/>
+   <tile gid="5686"/>
+   <tile gid="5685"/>
+   <tile gid="5351"/>
+   <tile gid="5502"/>
+   <tile gid="5546"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5544"/>
+   <tile gid="5351"/>
+   <tile gid="5422"/>
+   <tile gid="5423"/>
+   <tile gid="5424"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5560"/>
+   <tile gid="5561"/>
+   <tile gid="5562"/>
+   <tile gid="5683"/>
+   <tile gid="5684"/>
+   <tile gid="5395"/>
+   <tile gid="5396"/>
+   <tile gid="5359"/>
+   <tile gid="5358"/>
+   <tile gid="5359"/>
+   <tile gid="5358"/>
+   <tile gid="5399"/>
+   <tile gid="5437"/>
+   <tile gid="5351"/>
+   <tile gid="5686"/>
+   <tile gid="5685"/>
+   <tile gid="5686"/>
+   <tile gid="5502"/>
+   <tile gid="5546"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5544"/>
+   <tile gid="5351"/>
+   <tile gid="5462"/>
+   <tile gid="5463"/>
+   <tile gid="5464"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5600"/>
+   <tile gid="5601"/>
+   <tile gid="5602"/>
+   <tile gid="5351"/>
+   <tile gid="5355"/>
+   <tile gid="5358"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5399"/>
+   <tile gid="5437"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5685"/>
+   <tile gid="5686"/>
+   <tile gid="5685"/>
+   <tile gid="5582"/>
+   <tile gid="5506"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5545"/>
+   <tile gid="5503"/>
+   <tile gid="5503"/>
+   <tile gid="5503"/>
+   <tile gid="5504"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5435"/>
+   <tile gid="5436"/>
+   <tile gid="5436"/>
+   <tile gid="5398"/>
+   <tile gid="5396"/>
+   <tile gid="5399"/>
+   <tile gid="5437"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5686"/>
+   <tile gid="5685"/>
+   <tile gid="5686"/>
+   <tile gid="5351"/>
+   <tile gid="5582"/>
+   <tile gid="5583"/>
+   <tile gid="5506"/>
+   <tile gid="5505"/>
+   <tile gid="5583"/>
+   <tile gid="5506"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5543"/>
+   <tile gid="5544"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5360"/>
+   <tile gid="5361"/>
+   <tile gid="5361"/>
+   <tile gid="5362"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5435"/>
+   <tile gid="5398"/>
+   <tile gid="5359"/>
+   <tile gid="5357"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile gid="5582"/>
+   <tile gid="5584"/>
+   <tile/>
+   <tile gid="5582"/>
+   <tile gid="5506"/>
+   <tile gid="5505"/>
+   <tile gid="5583"/>
+   <tile gid="5583"/>
+   <tile gid="5583"/>
+   <tile gid="5584"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5400"/>
+   <tile gid="5391"/>
+   <tile gid="5394"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5435"/>
+   <tile gid="5398"/>
+   <tile gid="5397"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile gid="5360"/>
+   <tile gid="5362"/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5582"/>
+   <tile gid="5584"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5400"/>
+   <tile gid="5431"/>
+   <tile gid="5434"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5352"/>
+   <tile gid="5353"/>
+   <tile gid="5351"/>
+   <tile gid="5395"/>
+   <tile gid="5359"/>
+   <tile gid="5356"/>
+   <tile gid="5356"/>
+   <tile gid="5356"/>
+   <tile gid="5356"/>
+   <tile gid="5356"/>
+   <tile gid="5356"/>
+   <tile gid="5356"/>
+   <tile gid="5356"/>
+   <tile gid="5357"/>
+   <tile gid="5400"/>
+   <tile gid="5364"/>
+   <tile gid="5362"/>
+   <tile gid="5360"/>
+   <tile gid="5361"/>
+   <tile gid="5362"/>
+   <tile gid="5351"/>
+   <tile gid="5502"/>
+   <tile gid="5503"/>
+   <tile gid="5504"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5400"/>
+   <tile gid="5391"/>
+   <tile gid="5394"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile gid="5391"/>
+   <tile gid="5392"/>
+   <tile gid="5393"/>
+   <tile gid="5394"/>
+   <tile gid="5435"/>
+   <tile gid="5398"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5399"/>
+   <tile gid="5437"/>
+   <tile gid="5400"/>
+   <tile gid="5401"/>
+   <tile gid="5364"/>
+   <tile gid="5363"/>
+   <tile gid="5401"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile gid="5542"/>
+   <tile gid="5543"/>
+   <tile gid="5544"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5440"/>
+   <tile gid="5441"/>
+   <tile gid="5441"/>
+   <tile gid="5442"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5432"/>
+   <tile gid="5433"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5435"/>
+   <tile gid="5436"/>
+   <tile gid="5436"/>
+   <tile gid="5436"/>
+   <tile gid="5436"/>
+   <tile gid="5436"/>
+   <tile gid="5436"/>
+   <tile gid="5436"/>
+   <tile gid="5437"/>
+   <tile gid="5401"/>
+   <tile gid="5400"/>
+   <tile gid="5401"/>
+   <tile gid="5401"/>
+   <tile gid="5401"/>
+   <tile gid="5401"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile gid="5582"/>
+   <tile gid="5583"/>
+   <tile gid="5584"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5724"/>
+   <tile gid="5724"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5688"/>
+   <tile gid="5688"/>
+   <tile gid="5688"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5401"/>
+   <tile gid="5440"/>
+   <tile gid="5441"/>
+   <tile gid="5403"/>
+   <tile gid="5401"/>
+   <tile gid="5404"/>
+   <tile gid="5442"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5360"/>
+   <tile gid="5361"/>
+   <tile gid="5361"/>
+   <tile gid="5362"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5520"/>
+   <tile gid="5521"/>
+   <tile gid="5521"/>
+   <tile gid="5522"/>
+   <tile gid="5351"/>
+   <tile gid="5440"/>
+   <tile gid="5442"/>
+   <tile/>
+   <tile gid="5440"/>
+   <tile gid="5441"/>
+   <tile gid="5442"/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5360"/>
+   <tile gid="5361"/>
+   <tile gid="5362"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5400"/>
+   <tile gid="5391"/>
+   <tile gid="5394"/>
+   <tile gid="5364"/>
+   <tile gid="5361"/>
+   <tile gid="5361"/>
+   <tile gid="5361"/>
+   <tile gid="5361"/>
+   <tile gid="5361"/>
+   <tile gid="5361"/>
+   <tile gid="5362"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5560"/>
+   <tile gid="5561"/>
+   <tile gid="5561"/>
+   <tile gid="5562"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5360"/>
+   <tile gid="5361"/>
+   <tile gid="5361"/>
+   <tile gid="5361"/>
+   <tile gid="5361"/>
+   <tile gid="5363"/>
+   <tile gid="5401"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5400"/>
+   <tile gid="5431"/>
+   <tile gid="5434"/>
+   <tile gid="5401"/>
+   <tile gid="5401"/>
+   <tile gid="5351"/>
+   <tile gid="5352"/>
+   <tile gid="5353"/>
+   <tile gid="5351"/>
+   <tile gid="5401"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5560"/>
+   <tile gid="5561"/>
+   <tile gid="5561"/>
+   <tile gid="5728"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5683"/>
+   <tile gid="5351"/>
+   <tile gid="5352"/>
+   <tile gid="5353"/>
+   <tile gid="5351"/>
+   <tile gid="5401"/>
+   <tile gid="5401"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5400"/>
+   <tile gid="5391"/>
+   <tile gid="5394"/>
+   <tile gid="5401"/>
+   <tile gid="5401"/>
+   <tile gid="5391"/>
+   <tile gid="5392"/>
+   <tile gid="5393"/>
+   <tile gid="5394"/>
+   <tile gid="5401"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5560"/>
+   <tile gid="5561"/>
+   <tile gid="5561"/>
+   <tile gid="5728"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5683"/>
+   <tile gid="5391"/>
+   <tile gid="5392"/>
+   <tile gid="5393"/>
+   <tile gid="5394"/>
+   <tile gid="5401"/>
+   <tile gid="5401"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5400"/>
+   <tile gid="5401"/>
+   <tile gid="5401"/>
+   <tile gid="5401"/>
+   <tile gid="5401"/>
+   <tile gid="5351"/>
+   <tile gid="5432"/>
+   <tile gid="5433"/>
+   <tile gid="5351"/>
+   <tile gid="5401"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5560"/>
+   <tile gid="5561"/>
+   <tile gid="5561"/>
+   <tile gid="5562"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5400"/>
+   <tile gid="5351"/>
+   <tile gid="5432"/>
+   <tile gid="5433"/>
+   <tile gid="5351"/>
+   <tile gid="5441"/>
+   <tile gid="5403"/>
+   <tile gid="5402"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5440"/>
+   <tile gid="5441"/>
+   <tile gid="5441"/>
+   <tile gid="5441"/>
+   <tile gid="5441"/>
+   <tile gid="5441"/>
+   <tile gid="5441"/>
+   <tile gid="5441"/>
+   <tile gid="5441"/>
+   <tile gid="5441"/>
+   <tile gid="5442"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5600"/>
+   <tile gid="5601"/>
+   <tile gid="5601"/>
+   <tile gid="5602"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5440"/>
+   <tile gid="5441"/>
+   <tile gid="5441"/>
+   <tile gid="5441"/>
+   <tile gid="5442"/>
+   <tile gid="5351"/>
+   <tile gid="5440"/>
+   <tile gid="5442"/>
+   <tile gid="5351"/>
+   <tile/>
+   <tile/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
+   <tile gid="5351"/>
    <tile/>
   </data>
  </layer>
- <layer id="3" name="Collide" width="32" height="20">
+ <layer id="17" name="TerrainDecoration" width="34" height="21">
+  <data>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="4415"/>
+   <tile gid="4416"/>
+   <tile gid="4416"/>
+   <tile gid="4416"/>
+   <tile gid="4417"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="4455"/>
+   <tile gid="4411"/>
+   <tile gid="4491"/>
+   <tile gid="4451"/>
+   <tile gid="4457"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="4455"/>
+   <tile gid="4411"/>
+   <tile gid="4491"/>
+   <tile gid="4411"/>
+   <tile gid="4457"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="4495"/>
+   <tile gid="4496"/>
+   <tile gid="4496"/>
+   <tile gid="4496"/>
+   <tile gid="4497"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="4415"/>
+   <tile gid="4728"/>
+   <tile gid="4416"/>
+   <tile gid="4417"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="4455"/>
+   <tile gid="4491"/>
+   <tile gid="4491"/>
+   <tile gid="4457"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="4455"/>
+   <tile gid="4451"/>
+   <tile gid="4411"/>
+   <tile gid="4457"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="4455"/>
+   <tile gid="4451"/>
+   <tile gid="4451"/>
+   <tile gid="4457"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="4495"/>
+   <tile gid="4496"/>
+   <tile gid="4496"/>
+   <tile gid="4497"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5355"/>
+   <tile gid="5356"/>
+   <tile gid="5357"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5395"/>
+   <tile gid="5396"/>
+   <tile gid="5359"/>
+   <tile gid="5356"/>
+   <tile gid="5356"/>
+   <tile gid="5356"/>
+   <tile gid="5357"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5435"/>
+   <tile gid="5398"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5396"/>
+   <tile gid="5397"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5435"/>
+   <tile gid="5436"/>
+   <tile gid="5436"/>
+   <tile gid="5436"/>
+   <tile gid="5436"/>
+   <tile gid="5437"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+  </data>
+ </layer>
+ <layer id="18" name="Collide" width="34" height="21">
   <data>
    <tile gid="5406"/>
    <tile gid="5406"/>
@@ -1342,17 +1490,21 @@
    <tile gid="5406"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
-   <tile/>
-   <tile/>
-   <tile/>
    <tile gid="5406"/>
    <tile gid="5406"/>
-   <tile gid="5406"/>
+   <tile gid="5711"/>
    <tile/>
    <tile/>
    <tile/>
-   <tile/>
+   <tile gid="5711"/>
    <tile gid="5406"/>
+   <tile gid="5712"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5956"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5713"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
@@ -1360,43 +1512,79 @@
    <tile gid="5406"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
+   <tile gid="5712"/>
+   <tile gid="5673"/>
+   <tile gid="5956"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5792"/>
+   <tile/>
    <tile/>
    <tile/>
+   <tile gid="5752"/>
+   <tile gid="5793"/>
+   <tile gid="5753"/>
    <tile/>
    <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5752"/>
+   <tile gid="5793"/>
+   <tile gid="5673"/>
+   <tile gid="5956"/>
+   <tile gid="5673"/>
+   <tile gid="5713"/>
    <tile gid="5406"/>
+   <tile gid="5406"/>
+   <tile gid="5751"/>
+   <tile gid="6077"/>
    <tile/>
+   <tile gid="6077"/>
+   <tile gid="5966"/>
+   <tile gid="5967"/>
+   <tile gid="6550"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5968"/>
+   <tile gid="5969"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
    <tile/>
+   <tile gid="5712"/>
+   <tile gid="5753"/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
+   <tile gid="6077"/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
+   <tile gid="6077"/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1405,12 +1593,13 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6553"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5791"/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1418,12 +1607,14 @@
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1437,12 +1628,10 @@
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1450,15 +1639,21 @@
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
+   <tile/>
+   <tile/>
+   <tile gid="5791"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5672"/>
+   <tile gid="5674"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1466,15 +1661,13 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6553"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
+   <tile/>
    <tile/>
    <tile/>
    <tile/>
@@ -1486,31 +1679,33 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5672"/>
+   <tile gid="5713"/>
    <tile/>
-   <tile gid="5406"/>
-   <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6552"/>
+   <tile gid="5791"/>
    <tile/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
+   <tile gid="5671"/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1518,45 +1713,53 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="4729"/>
+   <tile gid="5794"/>
+   <tile gid="5956"/>
+   <tile gid="5674"/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5672"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5713"/>
    <tile/>
    <tile/>
+   <tile gid="5711"/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
-   <tile/>
-   <tile/>
-   <tile/>
    <tile gid="5406"/>
-   <tile/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
+   <tile gid="4480"/>
+   <tile gid="4606"/>
+   <tile gid="5751"/>
+   <tile gid="6554"/>
+   <tile gid="6550"/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1567,28 +1770,30 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5791"/>
    <tile/>
    <tile/>
+   <tile gid="5752"/>
+   <tile gid="5713"/>
    <tile/>
    <tile/>
+   <tile gid="5671"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile/>
-   <tile/>
    <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
+   <tile gid="4559"/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile/>
+   <tile gid="5751"/>
+   <tile gid="6554"/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1602,25 +1807,26 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6081"/>
+   <tile gid="5791"/>
    <tile/>
    <tile/>
+   <tile gid="5711"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
-   <tile/>
-   <tile/>
    <tile gid="5406"/>
-   <tile/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
+   <tile gid="6554"/>
+   <tile gid="6554"/>
    <tile/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1634,116 +1840,122 @@
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
    <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5752"/>
+   <tile gid="5793"/>
+   <tile gid="5793"/>
+   <tile gid="5713"/>
    <tile/>
    <tile/>
+   <tile gid="5712"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5674"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5671"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
-   <tile/>
-   <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
    <tile gid="5406"/>
-   <tile/>
-   <tile/>
-   <tile/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5711"/>
+   <tile gid="5752"/>
+   <tile gid="5754"/>
+   <tile gid="5753"/>
    <tile/>
    <tile/>
+   <tile gid="5791"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5711"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5672"/>
+   <tile gid="5713"/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
+   <tile gid="5791"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
+   <tile gid="5752"/>
+   <tile gid="5673"/>
+   <tile gid="5956"/>
+   <tile gid="5674"/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
+   <tile gid="5672"/>
+   <tile gid="5713"/>
    <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5752"/>
+   <tile gid="5673"/>
+   <tile gid="5956"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5956"/>
+   <tile gid="5674"/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile/>
-   <tile/>
+   <tile gid="5751"/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1754,32 +1966,29 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
+   <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
+   <tile gid="5623"/>
+   <tile gid="5623"/>
+   <tile gid="5623"/>
+   <tile gid="5623"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1789,15 +1998,19 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5918"/>
+   <tile gid="5919"/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5663"/>
+   <tile gid="5663"/>
+   <tile gid="5663"/>
+   <tile gid="5663"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1806,12 +2019,12 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
-   <tile/>
-   <tile/>
-   <tile/>
+   <tile gid="5751"/>
    <tile/>
+   <tile gid="6077"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1819,29 +2032,31 @@
    <tile/>
    <tile/>
    <tile/>
-   <tile/>
-   <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
+   <tile gid="5838"/>
+   <tile gid="5839"/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5663"/>
+   <tile gid="5663"/>
+   <tile gid="5663"/>
+   <tile gid="5663"/>
    <tile/>
    <tile/>
+   <tile gid="6079"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
-   <tile/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
-   <tile/>
-   <tile/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
@@ -1849,999 +2064,846 @@
    <tile/>
    <tile/>
    <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile gid="5406"/>
+   <tile gid="5918"/>
+   <tile gid="5919"/>
+   <tile gid="5878"/>
+   <tile gid="5879"/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile/>
+   <tile gid="5751"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5663"/>
+   <tile gid="5663"/>
+   <tile gid="5663"/>
+   <tile gid="5663"/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
-   <tile gid="5406"/>
+   <tile gid="5711"/>
+   <tile gid="5966"/>
+   <tile gid="5967"/>
+   <tile gid="5751"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
+   <tile gid="5752"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5753"/>
    <tile gid="5406"/>
+   <tile gid="5752"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5754"/>
+   <tile gid="5673"/>
+   <tile gid="5673"/>
+   <tile gid="5753"/>
    <tile gid="5406"/>
    <tile gid="5406"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
    <tile gid="5406"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
+   <tile gid="5366"/>
    <tile gid="5406"/>
   </data>
  </layer>
  <objectgroup id="5" name="Entities">
-  <object id="983" name="Piston W" type="Piston" gid="6541" x="352" y="192" width="32" height="32">
-   <properties>
-    <property name="direction" value="WEST"/>
-   </properties>
-  </object>
-  <object id="984" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="128" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="985" name="Launchpad" type="Launchpad" gid="6537" x="320" y="256" width="32" height="32"/>
-  <object id="986" name="Spring Trap" type="SpringTrap" gid="6538" x="608" y="512" width="32" height="32">
-   <properties>
-    <property name="trigger.landingCoordinates.x" type="int" value="25"/>
-    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
-   </properties>
-  </object>
-  <object id="988" name="Bridge Chest" type="Chest" gid="6544" x="192" y="416" width="32" height="32">
-   <properties>
-    <property name="item" value="DeployBridge"/>
-   </properties>
-  </object>
-  <object id="989" name="Magic Trap" type="Trap" gid="6755" x="352" y="320" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="5"/>
-    <property name="limitedTriggers" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="990" name="Spike Trap" type="Trap" gid="5911" x="288" y="192" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="992" name="Power Rune" type="BuffTile" gid="6611" x="256" y="544" width="32" height="32">
-   <properties>
-    <property name="atkBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="993" name="Counter Rune" type="BuffTile" gid="6619" x="416" y="320" width="32" height="32">
-   <properties>
-    <property name="retBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="994" name="Fortune Rune" type="BuffTile" gid="6615" x="416" y="192" width="32" height="32">
-   <properties>
-    <property name="luckBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="995" name="Stalwart Rune" type="BuffTile" gid="6607" x="224" y="576" width="32" height="32">
-   <properties>
-    <property name="blockBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="959" name="Deploy Blue" type="Deployment" gid="6342" x="672" y="128" width="32" height="32">
-   <properties>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="960" name="Deploy Red" type="Deployment" gid="6350" x="96" y="512" width="32" height="32">
+  <object id="978" name="Deploy Red" type="Deployment" gid="6350" x="576" y="192" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="973" name="Deploy Blue" type="Deployment" gid="6342" x="704" y="128" width="32" height="32">
+  <object id="980" name="Deploy Blue" type="Deployment" gid="6342" x="224" y="576" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
   </object>
-  <object id="974" name="Deploy Blue" type="Deployment" gid="6342" x="768" y="128" width="32" height="32">
-   <properties>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="975" name="Deploy Red" type="Deployment" gid="6350" x="128" y="480" width="32" height="32">
-   <properties>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="976" name="Deploy Red" type="Deployment" gid="6350" x="160" y="512" width="32" height="32">
-   <properties>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="977" name="Deploy Red" type="Deployment" gid="6350" x="128" y="544" width="32" height="32">
-   <properties>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="978" name="Deploy Red" type="Deployment" gid="6350" x="96" y="448" width="32" height="32">
-   <properties>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="979" name="Deploy Red" type="Deployment" gid="6350" x="64" y="480" width="32" height="32">
-   <properties>
-    <property name="Team" value="Red"/>
-   </properties>
-  </object>
-  <object id="980" name="Deploy Blue" type="Deployment" gid="6342" x="672" y="96" width="32" height="32">
-   <properties>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="981" name="Deploy Blue" type="Deployment" gid="6342" x="736" y="96" width="32" height="32">
-   <properties>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="982" name="Deploy Blue" type="Deployment" gid="6342" x="768" y="96" width="32" height="32">
-   <properties>
-    <property name="Team" value="Blue"/>
-   </properties>
-  </object>
-  <object id="997" name="Switch E" type="Switch" gid="6597" x="736" y="512" width="32" height="32">
-   <properties>
-    <property name="triggersId" value="Switch Door E"/>
-   </properties>
-  </object>
-  <object id="998" name="Switch Door E" type="Door" gid="6565" x="640" y="288" width="32" height="32">
-   <properties>
-    <property name="isLocked" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1000" name="Unlocked Door" type="Door" gid="6579" x="736" y="448" width="32" height="32">
-   <properties>
-    <property name="isLocked" type="bool" value="false"/>
-   </properties>
-  </object>
-  <object id="1002" name="Opened Door" type="Door" gid="2147490227" x="864" y="224" width="32" height="32">
+  <object id="1003" name="Opened Door" type="Door" gid="2147490228" x="608" y="192" width="32" height="32">
    <properties>
     <property name="isLocked" type="bool" value="false"/>
     <property name="isOpen" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1003" name="Opened Door" type="Door" gid="2147490227" x="864" y="192" width="32" height="32">
-   <properties>
-    <property name="isLocked" type="bool" value="false"/>
-    <property name="isOpen" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1004" name="Unlocked Door" type="Door" gid="6579" x="768" y="448" width="32" height="32">
-   <properties>
-    <property name="isLocked" type="bool" value="false"/>
-   </properties>
-  </object>
-  <object id="1005" name="Switch Door E" type="Door" gid="6565" x="640" y="320" width="32" height="32">
-   <properties>
-    <property name="isLocked" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1008" name="Opened Door" type="Door" gid="2147490227" x="160" y="192" width="32" height="32">
-   <properties>
-    <property name="isLocked" type="bool" value="false"/>
-    <property name="isOpen" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1009" name="Opened Door" type="Door" gid="2147490227" x="160" y="160" width="32" height="32">
-   <properties>
-    <property name="isLocked" type="bool" value="false"/>
-    <property name="isOpen" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1012" name="Spring Trap" type="SpringTrap" gid="6538" x="416" y="512" width="32" height="32">
-   <properties>
-    <property name="trigger.landingCoordinates.x" type="int" value="25"/>
-    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
-   </properties>
-  </object>
-  <object id="1013" name="Spring Trap" type="SpringTrap" gid="6538" x="416" y="544" width="32" height="32">
-   <properties>
-    <property name="trigger.landingCoordinates.x" type="int" value="25"/>
-    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
-   </properties>
-  </object>
-  <object id="1014" name="Spring Trap" type="SpringTrap" gid="6538" x="608" y="544" width="32" height="32">
-   <properties>
-    <property name="trigger.landingCoordinates.x" type="int" value="25"/>
-    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
-   </properties>
-  </object>
-  <object id="1015" name="Unlocked Door" type="Door" gid="6579" x="64" y="288" width="32" height="32">
-   <properties>
-    <property name="isLocked" type="bool" value="false"/>
-   </properties>
-  </object>
-  <object id="1016" name="Unlocked Door" type="Door" gid="6579" x="96" y="288" width="32" height="32">
-   <properties>
-    <property name="isLocked" type="bool" value="false"/>
-   </properties>
-  </object>
-  <object id="1017" name="Switch Door S" type="Door" gid="6565" x="352" y="448" width="32" height="32">
-   <properties>
-    <property name="isLocked" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1018" name="Switch Door S" type="Door" gid="6565" x="320" y="448" width="32" height="32">
-   <properties>
-    <property name="isLocked" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1019" name="Switch S" type="Switch" gid="6597" x="96" y="192" width="32" height="32">
-   <properties>
-    <property name="triggersId" value="Switch Door S"/>
-   </properties>
-  </object>
-  <object id="1020" name="Spike Trap" type="Trap" gid="5911" x="352" y="384" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1021" name="Spike Trap" type="Trap" gid="5911" x="256" y="288" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1022" name="Spike Trap" type="Trap" gid="5911" x="320" y="384" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1023" name="Spike Trap" type="Trap" gid="5911" x="256" y="352" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1025" name="Spike Trap" type="Trap" gid="5911" x="288" y="256" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1026" name="Spike Trap" type="Trap" gid="5911" x="288" y="224" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1028" name="Spike Trap" type="Trap" gid="5911" x="384" y="384" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1029" name="Spike Trap" type="Trap" gid="5911" x="224" y="416" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1030" name="Spike Trap" type="Trap" gid="5911" x="448" y="448" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1031" name="Spike Trap" type="Trap" gid="5911" x="352" y="288" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1032" name="Spike Trap" type="Trap" gid="5911" x="352" y="256" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1033" name="Spike Trap" type="Trap" gid="5911" x="384" y="288" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1034" name="Spike Trap" type="Trap" gid="5911" x="448" y="288" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1036" name="Spike Trap" type="Trap" gid="5911" x="224" y="96" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1037" name="Spike Trap" type="Trap" gid="5911" x="192" y="224" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1038" name="Spike Trap" type="Trap" gid="5911" x="416" y="288" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1039" name="Spike Trap" type="Trap" gid="5911" x="384" y="160" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1040" name="Spike Trap" type="Trap" gid="5911" x="384" y="192" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1041" name="Spike Trap" type="Trap" gid="5911" x="384" y="224" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1043" name="Spike Trap" type="Trap" gid="5911" x="192" y="96" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1044" name="Spike Trap" type="Trap" gid="5911" x="192" y="128" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1045" name="Spike Trap" type="Trap" gid="5911" x="256" y="96" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1047" name="Spike Trap" type="Trap" gid="5911" x="896" y="256" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1048" name="Spike Trap" type="Trap" gid="5911" x="928" y="256" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1049" name="Spike Trap" type="Trap" gid="5911" x="960" y="256" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1050" name="Spike Trap" type="Trap" gid="5911" x="896" y="288" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1051" name="Spike Trap" type="Trap" gid="5911" x="928" y="288" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1052" name="Spike Trap" type="Trap" gid="5911" x="960" y="288" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1053" name="Spike Trap" type="Trap" gid="5911" x="896" y="320" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1054" name="Spike Trap" type="Trap" gid="5911" x="928" y="320" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1055" name="Spike Trap" type="Trap" gid="5911" x="960" y="320" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1056" name="Spike Trap" type="Trap" gid="5911" x="896" y="352" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1057" name="Spike Trap" type="Trap" gid="5911" x="928" y="352" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1058" name="Spike Trap" type="Trap" gid="5911" x="960" y="352" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1059" name="Spike Trap" type="Trap" gid="5911" x="896" y="384" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1060" name="Spike Trap" type="Trap" gid="5911" x="928" y="384" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1061" name="Spike Trap" type="Trap" gid="5911" x="960" y="384" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1062" name="Spike Trap" type="Trap" gid="5911" x="896" y="416" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1063" name="Spike Trap" type="Trap" gid="5911" x="928" y="416" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1064" name="Spike Trap" type="Trap" gid="5911" x="960" y="416" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1065" name="Spike Trap" type="Trap" gid="5911" x="896" y="448" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1066" name="Spike Trap" type="Trap" gid="5911" x="928" y="448" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1067" name="Spike Trap" type="Trap" gid="5911" x="960" y="448" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1068" name="Spike Trap" type="Trap" gid="5911" x="896" y="480" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1069" name="Spike Trap" type="Trap" gid="5911" x="928" y="480" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1070" name="Spike Trap" type="Trap" gid="5911" x="960" y="480" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1071" name="Spike Trap" type="Trap" gid="5911" x="32" y="352" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1072" name="Spike Trap" type="Trap" gid="5911" x="64" y="352" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1073" name="Spike Trap" type="Trap" gid="5911" x="96" y="352" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1074" name="Spike Trap" type="Trap" gid="5911" x="32" y="384" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1075" name="Spike Trap" type="Trap" gid="5911" x="64" y="384" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1076" name="Spike Trap" type="Trap" gid="5911" x="96" y="384" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1077" name="Spike Trap" type="Trap" gid="5911" x="128" y="352" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1078" name="Spike Trap" type="Trap" gid="5911" x="128" y="384" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1079" name="Spike Trap" type="Trap" gid="5911" x="32" y="320" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1080" name="Spike Trap" type="Trap" gid="5911" x="64" y="320" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1081" name="Spike Trap" type="Trap" gid="5911" x="96" y="320" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1082" name="Spike Trap" type="Trap" gid="5911" x="128" y="320" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1083" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="160" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1084" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="192" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1085" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="224" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1086" name="Piston Pad W" type="PressurePlate" gid="6670" x="256" y="224" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1087" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="320" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1088" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="288" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1089" name="Piston Pad W" type="PressurePlate" gid="6670" x="256" y="256" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1090" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="320" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1091" name="Piston Pad W" type="PressurePlate" gid="6670" x="288" y="384" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1092" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="384" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1093" name="Piston Pad W" type="PressurePlate" gid="6670" x="256" y="384" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1094" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="352" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1095" name="Piston Pad W" type="PressurePlate" gid="6670" x="288" y="352" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1096" name="Piston Pad W" type="PressurePlate" gid="6670" x="288" y="416" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1097" name="Piston Pad W" type="PressurePlate" gid="6670" x="288" y="320" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1098" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="288" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1099" name="Piston Pad W" type="PressurePlate" gid="6670" x="256" y="128" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1100" name="Piston Pad W" type="PressurePlate" gid="6670" x="288" y="128" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1101" name="Piston Pad W" type="PressurePlate" gid="6670" x="352" y="128" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1102" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="160" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1103" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="128" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1114" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="224" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1115" name="Piston Pad W" type="PressurePlate" gid="6670" x="320" y="192" width="32" height="32">
-   <properties>
-    <property name="triggerOnRelease" type="bool" value="false"/>
-    <property name="triggersId" value="Piston W"/>
-   </properties>
-  </object>
-  <object id="1116" name="Piston W" type="Piston" gid="6541" x="352" y="224" width="32" height="32">
-   <properties>
-    <property name="direction" value="WEST"/>
-   </properties>
-  </object>
-  <object id="1117" name="Piston E" type="Piston" gid="6542" x="192" y="288" width="32" height="32">
-   <properties>
-    <property name="direction" value="EAST"/>
-   </properties>
-  </object>
-  <object id="1118" name="Piston E" type="Piston" gid="6542" x="192" y="320" width="32" height="32">
-   <properties>
-    <property name="direction" value="EAST"/>
-   </properties>
-  </object>
-  <object id="1119" name="Piston E" type="Piston" gid="6542" x="192" y="352" width="32" height="32">
-   <properties>
-    <property name="direction" value="EAST"/>
-   </properties>
-  </object>
-  <object id="1120" name="Piston E" type="Piston" gid="6542" x="192" y="384" width="32" height="32">
-   <properties>
-    <property name="direction" value="EAST"/>
-   </properties>
-  </object>
-  <object id="1122" name="Spike Trap" type="Trap" gid="5911" x="384" y="416" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="3"/>
-   </properties>
-  </object>
-  <object id="1123" name="Piston N" type="Piston" gid="6540" x="320" y="352" width="32" height="32">
-   <properties>
-    <property name="direction" value="NORTH"/>
-   </properties>
-  </object>
-  <object id="1124" name="Piston N" type="Piston" gid="6540" x="256" y="160" width="32" height="32">
-   <properties>
-    <property name="direction" value="NORTH"/>
-   </properties>
-  </object>
-  <object id="1126" name="Piston E" type="Piston" gid="6542" x="288" y="288" width="32" height="32">
-   <properties>
-    <property name="direction" value="EAST"/>
-   </properties>
-  </object>
-  <object id="1127" name="Piston N" type="Piston" gid="6540" x="256" y="416" width="32" height="32">
-   <properties>
-    <property name="direction" value="NORTH"/>
-   </properties>
-  </object>
-  <object id="1128" name="Launchpad" type="Launchpad" gid="6537" x="352" y="160" width="32" height="32"/>
-  <object id="1129" name="Launchpad" type="Launchpad" gid="6537" x="352" y="352" width="32" height="32"/>
-  <object id="1130" name="Piston E" type="Piston" gid="6542" x="224" y="256" width="32" height="32">
-   <properties>
-    <property name="direction" value="EAST"/>
-   </properties>
-  </object>
-  <object id="1131" name="Piston S" type="Piston" gid="6539" x="256" y="192" width="32" height="32">
+  <object id="1131" name="Piston S" type="Piston" gid="6539" x="448" y="320" width="32" height="32">
    <properties>
     <property name="direction" value="SOUTH"/>
    </properties>
   </object>
-  <object id="1132" name="Spike Trap" type="Trap" gid="5911" x="480" y="288" width="32" height="32">
+  <object id="1175" name="Rubble" type="BreakableObstacle" gid="6549" x="352" y="352" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1179" name="Locked Door" type="Door" gid="6565" x="320" y="448" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1184" name="Spring Trap" type="SpringTrap" gid="6538" x="288" y="192" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="11"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="5"/>
+   </properties>
+  </object>
+  <object id="1185" name="Spring Trap" type="SpringTrap" gid="6538" x="320" y="224" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="9"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="7"/>
+   </properties>
+  </object>
+  <object id="1186" name="Spring Trap" type="SpringTrap" gid="6538" x="288" y="256" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="9"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="9"/>
+   </properties>
+  </object>
+  <object id="1187" name="Spring Trap" type="SpringTrap" gid="6538" x="352" y="288" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="6"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="5"/>
+   </properties>
+  </object>
+  <object id="1188" name="Spike Trap" type="Trap" gid="5911" x="448" y="384" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
    </properties>
   </object>
-  <object id="1133" name="Spike Trap" type="Trap" gid="5911" x="480" y="256" width="32" height="32">
+  <object id="1189" name="Piston Pad S" type="PressurePlate" gid="6670" x="480" y="352" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston S"/>
+   </properties>
+  </object>
+  <object id="1190" name="Spike Trap" type="Trap" gid="5911" x="416" y="384" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
    </properties>
   </object>
-  <object id="1134" name="Spike Trap" type="Trap" gid="5911" x="416" y="416" width="32" height="32">
+  <object id="1191" name="Spike Trap" type="Trap" gid="5911" x="480" y="384" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
    </properties>
   </object>
-  <object id="1135" name="Spike Trap" type="Trap" gid="5911" x="448" y="416" width="32" height="32">
+  <object id="1192" name="Piston S" type="Piston" gid="6539" x="480" y="320" width="32" height="32">
+   <properties>
+    <property name="direction" value="SOUTH"/>
+   </properties>
+  </object>
+  <object id="1193" name="Piston Pad S" type="PressurePlate" gid="6670" x="416" y="352" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston S"/>
+   </properties>
+  </object>
+  <object id="1194" name="Piston S" type="Piston" gid="6539" x="416" y="320" width="32" height="32">
+   <properties>
+    <property name="direction" value="SOUTH"/>
+   </properties>
+  </object>
+  <object id="1196" name="Escape" type="Escape" gid="6864" x="544" y="96" width="32" height="32"/>
+  <object id="1197" name="Escape" type="Escape" gid="6864" x="512" y="96" width="32" height="32"/>
+  <object id="1198" name="Escape" type="Escape" gid="6864" x="576" y="96" width="32" height="32"/>
+  <object id="1199" name="Launchpad" type="Launchpad" gid="6537" x="768" y="384" width="32" height="32">
+   <properties>
+    <property name="radius" value="2,3,4"/>
+   </properties>
+  </object>
+  <object id="1200" name="Locked Door" type="Door" gid="6565" x="352" y="448" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1201" name="Unlocked Door" type="Door" gid="6579" x="512" y="448" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+    <property name="isOpen" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1202" name="Unlocked Door" type="Door" gid="6579" x="544" y="448" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+    <property name="isOpen" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1203" name="Unlocked Door" type="Door" gid="6579" x="576" y="448" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+    <property name="isOpen" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1204" name="Gate" type="Door" gid="6571" x="832" y="352" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1205" name="Gate" type="Door" gid="6571" x="864" y="352" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1206" name="Gate" type="Door" gid="6571" x="736" y="320" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1207" name="Gate" type="Door" gid="6571" x="704" y="320" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1209" name="Spike Trap" type="Trap" gid="5911" x="512" y="384" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
    </properties>
   </object>
-  <object id="1138" name="Spike Trap" type="Trap" gid="5911" x="384" y="96" width="32" height="32">
+  <object id="1210" name="Piston S" type="Piston" gid="6539" x="512" y="320" width="32" height="32">
+   <properties>
+    <property name="direction" value="SOUTH"/>
+   </properties>
+  </object>
+  <object id="1211" name="Piston S" type="Piston" gid="6539" x="576" y="320" width="32" height="32">
+   <properties>
+    <property name="direction" value="SOUTH"/>
+   </properties>
+  </object>
+  <object id="1212" name="Spike Trap" type="Trap" gid="5911" x="576" y="384" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
    </properties>
   </object>
-  <object id="1139" name="Spike Trap" type="Trap" gid="5911" x="416" y="96" width="32" height="32">
+  <object id="1214" name="Spike Trap" type="Trap" gid="5911" x="544" y="384" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
    </properties>
   </object>
-  <object id="1145" name="Magic Trap" type="Trap" gid="6755" x="384" y="256" width="32" height="32">
+  <object id="1215" name="Spike Trap" type="Trap" gid="5911" x="608" y="384" width="32" height="32">
    <properties>
-    <property name="damage" type="int" value="5"/>
-    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="damage" type="int" value="3"/>
    </properties>
   </object>
-  <object id="1146" name="Piston Pad W" type="PressurePlate" gid="6670" x="384" y="128" width="32" height="32">
+  <object id="1216" name="Piston S" type="Piston" gid="6539" x="608" y="320" width="32" height="32">
+   <properties>
+    <property name="direction" value="SOUTH"/>
+   </properties>
+  </object>
+  <object id="1218" name="Piston S" type="Piston" gid="6539" x="544" y="320" width="32" height="32">
+   <properties>
+    <property name="direction" value="SOUTH"/>
+   </properties>
+  </object>
+  <object id="1219" name="Piston Pad S" type="PressurePlate" gid="6670" x="576" y="352" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston S"/>
+   </properties>
+  </object>
+  <object id="1220" name="Piston Pad S" type="PressurePlate" gid="6670" x="640" y="352" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston S"/>
+   </properties>
+  </object>
+  <object id="1221" name="Spike Trap" type="Trap" gid="5911" x="640" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1222" name="Piston S" type="Piston" gid="6539" x="640" y="320" width="32" height="32">
+   <properties>
+    <property name="direction" value="SOUTH"/>
+   </properties>
+  </object>
+  <object id="1223" name="Deploy Red" type="Deployment" gid="6350" x="928" y="544" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="1224" name="Deploy Red" type="Deployment" gid="6350" x="704" y="224" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="1225" name="Deploy Red" type="Deployment" gid="6350" x="928" y="256" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="1226" name="Deploy Red" type="Deployment" gid="6350" x="544" y="544" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="1227" name="Deploy Blue" type="Deployment" gid="6342" x="224" y="544" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="1228" name="Deploy Blue" type="Deployment" gid="6342" x="256" y="544" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="1229" name="Deploy Blue" type="Deployment" gid="6342" x="256" y="576" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="1230" name="Deploy Blue" type="Deployment" gid="6342" x="192" y="576" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="1232" name="Deploy Blue" type="Deployment" gid="6342" x="192" y="544" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="1234" name="Regal Chest" type="Chest" gid="6686" x="96" y="160" width="32" height="32">
+   <properties>
+    <property name="item" value="Free Contract"/>
+   </properties>
+  </object>
+  <object id="1235" name="Rubble" type="BreakableObstacle" gid="6549" x="384" y="320" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1236" name="Push Block" type="Pushable" gid="6637" x="352" y="384" width="32" height="32"/>
+  <object id="1237" name="Push Block" type="Pushable" gid="6637" x="320" y="384" width="32" height="32"/>
+  <object id="1238" name="Piston S" type="Piston" gid="6539" x="256" y="128" width="32" height="32">
+   <properties>
+    <property name="direction" value="SOUTH"/>
+   </properties>
+  </object>
+  <object id="1239" name="Piston E" type="Piston" gid="6542" x="224" y="192" width="32" height="32">
+   <properties>
+    <property name="direction" value="EAST"/>
+   </properties>
+  </object>
+  <object id="1241" name="Piston S" type="Piston" gid="6539" x="352" y="160" width="32" height="32">
+   <properties>
+    <property name="direction" value="SOUTH"/>
+   </properties>
+  </object>
+  <object id="1242" name="Piston W" type="Piston" gid="6541" x="384" y="224" width="32" height="32">
+   <properties>
+    <property name="direction" value="WEST"/>
+   </properties>
+  </object>
+  <object id="1243" name="Piston Pad S" type="PressurePlate" gid="6670" x="256" y="160" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston S"/>
+   </properties>
+  </object>
+  <object id="1244" name="Piston Pad E" type="PressurePlate" gid="6670" x="256" y="192" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston E"/>
+   </properties>
+  </object>
+  <object id="1245" name="Piston Pad S" type="PressurePlate" gid="6670" x="352" y="192" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston S"/>
+   </properties>
+  </object>
+  <object id="1246" name="Piston Pad W" type="PressurePlate" gid="6670" x="352" y="224" width="32" height="32">
    <properties>
     <property name="triggerOnRelease" type="bool" value="false"/>
     <property name="triggersId" value="Piston W"/>
    </properties>
   </object>
-  <object id="1147" name="Magic Trap" type="Trap" gid="6755" x="288" y="160" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="5"/>
-    <property name="limitedTriggers" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1148" name="Magic Trap" type="Trap" gid="6755" x="288" y="96" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="5"/>
-    <property name="limitedTriggers" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1149" name="Magic Trap" type="Trap" gid="6755" x="320" y="96" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="5"/>
-    <property name="limitedTriggers" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1150" name="Magic Trap" type="Trap" gid="6755" x="352" y="96" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="5"/>
-    <property name="limitedTriggers" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1151" name="Magic Trap" type="Trap" gid="6755" x="256" y="320" width="32" height="32">
-   <properties>
-    <property name="damage" type="int" value="5"/>
-    <property name="limitedTriggers" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="1152" name="Power Rune" type="BuffTile" gid="6611" x="544" y="256" width="32" height="32">
-   <properties>
-    <property name="atkBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="1153" name="Counter Rune" type="BuffTile" gid="6619" x="256" y="512" width="32" height="32">
+  <object id="1247" name="Counter Rune" type="BuffTile" gid="6619" x="288" y="224" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1154" name="Fortune Rune" type="BuffTile" gid="6615" x="480" y="352" width="32" height="32">
+  <object id="1248" name="Fortune Rune" type="BuffTile" gid="6615" x="320" y="192" width="32" height="32">
    <properties>
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1155" name="Stalwart Rune" type="BuffTile" gid="6607" x="704" y="384" width="32" height="32">
+  <object id="1249" name="Fortune Rune" type="BuffTile" gid="6615" x="320" y="256" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1251" name="Power Rune" type="BuffTile" gid="6611" x="320" y="288" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1252" name="Magic Trap" type="Trap" gid="6755" x="352" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1253" name="Magic Trap" type="Trap" gid="6755" x="832" y="544" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1254" name="Magic Trap" type="Trap" gid="6755" x="960" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1255" name="Magic Trap" type="Trap" gid="6755" x="864" y="160" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1256" name="Ladder" type="Movable" gid="6661" x="768" y="480" width="32" height="32"/>
+  <object id="1257" name="Ladder" type="Movable" gid="6661" x="800" y="480" width="32" height="32"/>
+  <object id="1258" name="Ladder" type="Movable" gid="6661" x="832" y="480" width="32" height="32"/>
+  <object id="1259" name="Ballista" type="Railgun" gid="6733" x="672" y="352" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="7"/>
+   </properties>
+  </object>
+  <object id="1262" name="Dead Pad" type="Decoration" gid="6678" x="448" y="352" width="32" height="32"/>
+  <object id="1263" name="Dead Pad" type="Decoration" gid="6678" x="512" y="352" width="32" height="32"/>
+  <object id="1264" name="Dead Pad" type="Decoration" gid="6678" x="544" y="352" width="32" height="32"/>
+  <object id="1265" name="Dead Pad" type="Decoration" gid="6678" x="608" y="352" width="32" height="32"/>
+  <object id="1267" name="Gate Switch" type="Switch" gid="6595" x="800" y="288" width="32" height="32">
+   <properties>
+    <property name="triggersId" value="Gate"/>
+   </properties>
+  </object>
+  <object id="1269" name="Rubble" type="BreakableObstacle" gid="6549" x="320" y="160" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1271" name="Rubble" type="BreakableObstacle" gid="6549" x="224" y="224" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1272" name="Rubble" type="BreakableObstacle" gid="6549" x="224" y="256" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1273" name="Rubble" type="BreakableObstacle" gid="6549" x="416" y="160" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1274" name="Spike Trap" type="Trap" gid="5911" x="256" y="224" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1275" name="Spike Trap" type="Trap" gid="5911" x="256" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1276" name="Spike Trap" type="Trap" gid="5911" x="384" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1277" name="Spike Trap" type="Trap" gid="5911" x="416" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1278" name="Spike Trap" type="Trap" gid="5911" x="384" y="192" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1279" name="Spike Trap" type="Trap" gid="5911" x="288" y="160" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1280" name="Spike Trap" type="Trap" gid="5911" x="320" y="128" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1281" name="Spike Trap" type="Trap" gid="5911" x="288" y="128" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1282" name="Spike Trap" type="Trap" gid="5911" x="352" y="128" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1283" name="Spike Trap" type="Trap" gid="5911" x="384" y="128" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1284" name="Spike Trap" type="Trap" gid="5911" x="384" y="160" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1285" name="Spike Trap" type="Trap" gid="5911" x="416" y="192" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1286" name="Spike Trap" type="Trap" gid="5911" x="416" y="224" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1287" name="Rubble" type="BreakableObstacle" gid="6549" x="448" y="192" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1289" name="Regal Chest" type="Chest" gid="6694" x="960" y="160" width="32" height="32">
+   <properties>
+    <property name="item" value="Blink Bone"/>
+   </properties>
+  </object>
+  <object id="1298" name="Spike Trap" type="Trap" gid="5911" x="704" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1299" name="Spike Trap" type="Trap" gid="5911" x="736" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1300" name="Spike Trap" type="Trap" gid="5911" x="832" y="320" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1301" name="Spike Trap" type="Trap" gid="5911" x="864" y="320" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="1302" name="Stairs" type="Movable" gid="6603" x="928" y="448" width="32" height="32"/>
+  <object id="1303" name="Stairs" type="Movable" gid="6603" x="960" y="448" width="32" height="32"/>
+  <object id="1304" name="Stairs" type="Movable" gid="6603" x="992" y="448" width="32" height="32"/>
+  <object id="1305" name="Stairs" type="Movable" gid="6603" x="928" y="320" width="32" height="32"/>
+  <object id="1306" name="Stairs" type="Movable" gid="6603" x="960" y="320" width="32" height="32"/>
+  <object id="1307" name="Stairs" type="Movable" gid="6603" x="992" y="320" width="32" height="32"/>
+  <object id="1308" name="Power Rune" type="BuffTile" gid="6611" x="800" y="160" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1310" name="Stalwart Rune" type="BuffTile" gid="6607" x="704" y="128" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1156" name="Power Rune" type="BuffTile" gid="6611" x="480" y="416" width="32" height="32">
-   <properties>
-    <property name="atkBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="1157" name="Counter Rune" type="BuffTile" gid="6619" x="544" y="384" width="32" height="32">
+  <object id="1311" name="Counter Rune" type="BuffTile" gid="6619" x="800" y="224" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1158" name="Fortune Rune" type="BuffTile" gid="6615" x="576" y="320" width="32" height="32">
-   <properties>
-    <property name="luckBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="1160" name="Fortune Rune" type="BuffTile" gid="6615" x="224" y="480" width="32" height="32">
-   <properties>
-    <property name="luckBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="1162" name="Power Rune" type="BuffTile" gid="6611" x="672" y="512" width="32" height="32">
+  <object id="1312" name="Power Rune" type="BuffTile" gid="6611" x="736" y="160" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1163" name="Stalwart Rune" type="BuffTile" gid="6607" x="704" y="576" width="32" height="32">
+  <object id="1313" name="Stalwart Rune" type="BuffTile" gid="6607" x="832" y="192" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1164" name="Counter Rune" type="BuffTile" gid="6619" x="672" y="544" width="32" height="32">
+  <object id="1314" name="Stalwart Rune" type="BuffTile" gid="6607" x="832" y="128" width="32" height="32">
    <properties>
-    <property name="retBonus" type="int" value="1"/>
+    <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1165" name="Fortune Rune" type="BuffTile" gid="6615" x="704" y="480" width="32" height="32">
-   <properties>
-    <property name="luckBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="1166" name="Bridge Chest" type="Chest" gid="6544" x="736" y="320" width="32" height="32">
-   <properties>
-    <property name="item" value="DeployBridge"/>
-   </properties>
-  </object>
-  <object id="1167" name="Bridge Chest" type="Chest" gid="6544" x="96" y="96" width="32" height="32">
-   <properties>
-    <property name="item" value="DeployBridge"/>
-   </properties>
-  </object>
-  <object id="1168" name="Power Rune" type="BuffTile" gid="6611" x="64" y="192" width="32" height="32">
+  <object id="1315" name="Power Rune" type="BuffTile" gid="6611" x="768" y="128" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1170" name="Counter Rune" type="BuffTile" gid="6619" x="96" y="160" width="32" height="32">
-   <properties>
-    <property name="retBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="1171" name="Fortune Rune" type="BuffTile" gid="6615" x="96" y="224" width="32" height="32">
-   <properties>
-    <property name="luckBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="1172" name="Power Rune" type="BuffTile" gid="6611" x="512" y="128" width="32" height="32">
+  <object id="1316" name="Power Rune" type="BuffTile" gid="6611" x="768" y="192" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1173" name="Counter Rune" type="BuffTile" gid="6619" x="512" y="96" width="32" height="32">
-   <properties>
-    <property name="retBonus" type="int" value="1"/>
-   </properties>
-  </object>
-  <object id="1174" name="Fortune Rune" type="BuffTile" gid="6615" x="512" y="160" width="32" height="32">
+  <object id="1317" name="Fortune Rune" type="BuffTile" gid="6615" x="672" y="192" width="32" height="32">
    <properties>
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1175" name="Rubble" type="BreakableObstacle" gid="6593" x="512" y="320" width="32" height="32">
+  <object id="1318" name="Fortune Rune" type="BuffTile" gid="6615" x="672" y="128" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1319" name="Counter Rune" type="BuffTile" gid="6619" x="736" y="96" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1320" name="Counter Rune" type="BuffTile" gid="6619" x="736" y="224" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1324" name="Fortune Rune" type="BuffTile" gid="6615" x="864" y="128" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1325" name="Fortune Rune" type="BuffTile" gid="6615" x="864" y="192" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1328" name="Magic Trap" type="Trap" gid="6755" x="704" y="160" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1329" name="Magic Trap" type="Trap" gid="6755" x="832" y="160" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1330" name="Stalwart Rune" type="BuffTile" gid="6607" x="704" y="192" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1331" name="Magic Trap" type="Trap" gid="6755" x="736" y="192" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1332" name="Magic Trap" type="Trap" gid="6755" x="800" y="128" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1333" name="Magic Trap" type="Trap" gid="6755" x="800" y="192" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1334" name="Counter Rune" type="BuffTile" gid="6619" x="800" y="96" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1335" name="Magic Trap" type="Trap" gid="6755" x="672" y="160" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1336" name="Stairs" type="Movable" gid="6603" x="128" y="448" width="32" height="32"/>
+  <object id="1337" name="Stairs" type="Movable" gid="6603" x="96" y="448" width="32" height="32"/>
+  <object id="1338" name="Stairs" type="Movable" gid="6603" x="64" y="256" width="32" height="32"/>
+  <object id="1339" name="Stairs" type="Movable" gid="6603" x="128" y="256" width="32" height="32"/>
+  <object id="1340" name="Stairs" type="Movable" gid="6603" x="96" y="256" width="32" height="32"/>
+  <object id="1341" name="Drawbridge" type="Drawbridge" gid="6380" x="672" y="544" width="32" height="32"/>
+  <object id="1342" name="Drawbridge" type="Drawbridge" gid="6380" x="672" y="576" width="32" height="32"/>
+  <object id="1343" name="Drawbridge" type="Drawbridge" gid="6380" x="704" y="544" width="32" height="32"/>
+  <object id="1344" name="Drawbridge" type="Drawbridge" gid="6380" x="704" y="576" width="32" height="32"/>
+  <object id="1345" name="Bridge Switch" type="Switch" gid="6595" x="608" y="512" width="32" height="32">
+   <properties>
+    <property name="triggersId" value="Drawbridge"/>
+   </properties>
+  </object>
+  <object id="1346" name="Stairs" type="Movable" gid="6603" x="64" y="448" width="32" height="32"/>
+  <object id="1347" name="Stairs" type="Movable" gid="6603" x="160" y="448" width="32" height="32"/>
+  <object id="1348" name="Stairs" type="Movable" gid="6603" x="352" y="480" width="32" height="32"/>
+  <object id="1349" name="Stairs" type="Movable" gid="6603" x="320" y="480" width="32" height="32"/>
+  <object id="1352" name="Opened Door" type="Door" gid="2147490228" x="608" y="224" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="false"/>
+    <property name="isOpen" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1353" name="Stairs" type="Movable" gid="6603" x="512" y="416" width="32" height="32"/>
+  <object id="1354" name="Stairs" type="Movable" gid="6603" x="544" y="416" width="32" height="32"/>
+  <object id="1355" name="Stairs" type="Movable" gid="6603" x="576" y="416" width="32" height="32"/>
+  <object id="1356" name="Drawbridge" type="Drawbridge" gid="6379" x="640" y="544" width="32" height="32"/>
+  <object id="1357" name="Drawbridge" type="Drawbridge" gid="6379" x="640" y="576" width="32" height="32"/>
+  <object id="1358" name="Drawbridge" type="Drawbridge" gid="6381" x="736" y="544" width="32" height="32"/>
+  <object id="1359" name="Drawbridge" type="Drawbridge" gid="6381" x="736" y="576" width="32" height="32"/>
+  <object id="1366" name="Escape" type="Escape" gid="6864" x="544" y="64" width="32" height="32"/>
+  <object id="1367" name="Escape" type="Escape" gid="6864" x="512" y="64" width="32" height="32"/>
+  <object id="1368" name="Escape" type="Escape" gid="6864" x="576" y="64" width="32" height="32"/>
+  <object id="1369" name="Bridge Switch" type="Switch" gid="6595" x="768" y="608" width="32" height="32">
+   <properties>
+    <property name="triggersId" value="Drawbridge"/>
+   </properties>
+  </object>
+  <object id="1370" name="Launchpad" type="Launchpad" gid="6537" x="128" y="512" width="32" height="32">
+   <properties>
+    <property name="radius" value="2,3,4"/>
+   </properties>
+  </object>
+  <object id="1383" name="Shifty Character" type="Vendor" gid="6527" x="160" y="352" width="32" height="32">
+   <properties>
+    <property name="interactRange" value="1,2"/>
+    <property name="items" value="Swift Cheese|Alert Berries|Mighty Meat|Lucky Lemon|Healthy Potion"/>
+    <property name="prices" value="0|0|0|0|0"/>
+    <property name="quantities" value="3|3|3|3|3"/>
+   </properties>
+  </object>
+  <object id="1384" name="Rubble" type="BreakableObstacle" gid="5958" x="640" y="416" width="32" height="32">
    <properties>
     <property name="HP" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1176" name="Rubble" type="BreakableObstacle" gid="6593" x="544" y="352" width="32" height="32">
+  <object id="1385" name="Rubble" type="BreakableObstacle" gid="5958" x="672" y="448" width="32" height="32">
    <properties>
     <property name="HP" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1177" name="Rubble" type="BreakableObstacle" gid="6593" x="512" y="384" width="32" height="32">
+  <object id="1387" name="Rubble" type="BreakableObstacle" gid="5958" x="384" y="512" width="32" height="32">
    <properties>
     <property name="HP" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1178" name="Rubble" type="BreakableObstacle" gid="6593" x="512" y="352" width="32" height="32">
+  <object id="1388" name="Rubble" type="BreakableObstacle" gid="5958" x="320" y="576" width="32" height="32">
    <properties>
     <property name="HP" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1179" name="Switch Door E" type="Door" gid="6565" x="672" y="256" width="32" height="32">
+  <object id="1389" name="Rubble" type="BreakableObstacle" gid="5958" x="256" y="608" width="32" height="32">
    <properties>
-    <property name="isLocked" type="bool" value="true"/>
+    <property name="HP" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1180" name="Switch Door E" type="Door" gid="6565" x="704" y="256" width="32" height="32">
+  <object id="1390" name="Ballista" type="Railgun" gid="6733" x="800" y="576" width="32" height="32">
    <properties>
-    <property name="isLocked" type="bool" value="true"/>
+    <property name="range" type="int" value="7"/>
+   </properties>
+  </object>
+  <object id="1391" name="Ballista" type="Railgun" gid="6733" x="800" y="544" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="7"/>
+   </properties>
+  </object>
+  <object id="1392" name="Ballista" type="Railgun" gid="6733" x="384" y="384" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="7"/>
+   </properties>
+  </object>
+  <object id="1393" name="Deploy Red" type="Deployment" gid="6350" x="960" y="416" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
    </properties>
   </object>
  </objectgroup>
  <objectgroup id="6" name="Loot" opacity="0.58">
-  <object id="987" name="DeployBridge" type="LadderBridge" gid="6662" x="160" y="416" width="32" height="32"/>
+  <object id="1231" name="Door Key" type="Key" gid="6399" x="320" y="320" width="32" height="32">
+   <properties>
+    <property name="usedWith" value="Locked Door"/>
+   </properties>
+  </object>
+  <object id="1290" name="Blink Bone" type="Blink" gid="6423" x="960" y="128" width="32" height="32">
+   <properties>
+    <property name="usesRemaining" type="int" value="5"/>
+   </properties>
+  </object>
+  <object id="1233" name="Free Contract" type="Contract" gid="6471" x="96" y="128" width="32" height="32">
+   <properties>
+    <property name="forSpecificUnit" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1377" name="Healthy Potion" type="HealthPotion" gid="6759" x="192" y="384" width="32" height="32"/>
+  <object id="1378" name="Mighty Meat" type="BuffItem" gid="6792" x="192" y="320" width="32" height="32"/>
+  <object id="1379" name="Lucky Lemon" type="BuffItem" gid="6778" x="192" y="352" width="32" height="32">
+   <properties>
+    <property name="duration" type="int" value="2"/>
+    <property name="modifier" type="int" value="2"/>
+    <property name="stat" value="LCK"/>
+   </properties>
+  </object>
+  <object id="1380" name="Alert Berries" type="BuffItem" gid="6777" x="192" y="288" width="32" height="32">
+   <properties>
+    <property name="duration" type="int" value="2"/>
+    <property name="modifier" type="int" value="2"/>
+    <property name="stat" value="RET"/>
+   </properties>
+  </object>
+  <object id="1381" name="Swift Cheese" type="BuffItem" gid="6767" x="192" y="256" width="32" height="32">
+   <properties>
+    <property name="duration" type="int" value="2"/>
+    <property name="modifier" type="int" value="2"/>
+    <property name="stat" value="MV"/>
+   </properties>
+  </object>
  </objectgroup>
  <objectgroup id="11" name="Summons" opacity="0.69">
-  <object id="961" name="Slime" type="Creep" gid="21" x="32" y="32" width="32" height="32">
+  <object id="961" name="Slime" type="Creep" gid="21" x="64" y="64" width="32" height="32">
    <properties>
     <property name="Class" value="Slime"/>
     <property name="routine_glutton" type="bool" value="true"/>
@@ -2850,7 +2912,7 @@
     <property name="routine_treasureHunter" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="971" name="Skeleton" type="Creep" gid="26" x="0" y="32" width="32" height="32">
+  <object id="971" name="Skeleton" type="Creep" gid="26" x="32" y="64" width="32" height="32">
    <properties>
     <property name="Class" value="Skeleton"/>
     <property name="routine_defender" type="bool" value="true"/>
@@ -2858,93 +2920,130 @@
   </object>
  </objectgroup>
  <objectgroup id="7" name="Items">
-  <object id="991" name="Arcane Flint [R]" type="RecallCharm" gid="6809" x="928" y="320" width="32" height="32">
+  <object id="996" name="Magnet" type="Magnet" gid="6826" x="256" y="352" width="32" height="32"/>
+  <object id="1141" name="Arcane Flint [B]" type="RecallCharm" gid="6809" x="704" y="416" width="32" height="32">
    <properties>
-    <property name="recallId" value="Return Point [R]"/>
+    <property name="recallId" value="Return Point [B]"/>
    </properties>
   </object>
-  <object id="996" name="Magnet" type="Magnet" gid="6826" x="320" y="96" width="32" height="32"/>
-  <object id="1141" name="Arcane Flint [K]" type="RecallCharm" gid="6809" x="288" y="160" width="32" height="32">
+  <object id="1266" name="Arcane Flint [A]" type="RecallCharm" gid="6809" x="800" y="256" width="32" height="32">
    <properties>
-    <property name="recallId" value="Return Point [K]"/>
+    <property name="recallId" value="Return Point [A]"/>
    </properties>
   </object>
-  <object id="1142" name="Magnet" type="Magnet" gid="6826" x="384" y="256" width="32" height="32"/>
-  <object id="1143" name="Magnet" type="Magnet" gid="6826" x="256" y="320" width="32" height="32"/>
-  <object id="1144" name="Magnet" type="Magnet" gid="6826" x="928" y="416" width="32" height="32"/>
+  <object id="1291" name="Magnet" type="Magnet" gid="6826" x="192" y="160" width="32" height="32"/>
+  <object id="1292" name="Arcane Flint [C]" type="RecallCharm" gid="6809" x="128" y="512" width="32" height="32">
+   <properties>
+    <property name="recallId" value="Return Point [C]"/>
+   </properties>
+  </object>
+  <object id="1293" name="Holy Altar" type="RecoveryTile" gid="6627" x="768" y="160" width="32" height="32">
+   <properties>
+    <property name="hpPerTurn" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1295" name="Holy Altar" type="RecoveryTile" gid="6627" x="960" y="512" width="32" height="32">
+   <properties>
+    <property name="hpPerTurn" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1296" name="Stalwart Altar" type="RecoveryTile" gid="6623" x="576" y="576" width="32" height="32">
+   <properties>
+    <property name="amrPerTurn" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1297" name="Stalwart Altar" type="RecoveryTile" gid="6623" x="832" y="416" width="32" height="32">
+   <properties>
+    <property name="amrPerTurn" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1327" name="Magic Trap" type="Trap" gid="6755" x="736" y="128" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
  </objectgroup>
- <objectgroup id="8" name="Units"/>
- <objectgroup id="9" name="Disabled" opacity="0.43">
-  <object id="963" name="Slime" type="Creep" gid="21" x="544" y="576" width="32" height="32">
-   <properties>
-    <property name="Class" value="Slime"/>
-    <property name="routine_glutton" type="bool" value="true"/>
-    <property name="routine_summon" type="bool" value="true"/>
-    <property name="routine_summon.class" value="Slime"/>
-    <property name="routine_treasureHunter" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="965" name="Orc" type="Creep" gid="23" x="512" y="512" width="32" height="32">
-   <properties>
-    <property name="Class" value="Orc"/>
-    <property name="routine_glutton" type="bool" value="true"/>
-    <property name="routine_kingslayer" type="bool" value="true"/>
-    <property name="routine_prey" type="bool" value="true"/>
-    <property name="routine_treasureHunter" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="966" name="Rat" type="Creep" gid="29" x="576" y="608" width="32" height="32">
-   <properties>
-    <property name="Class" value="Rat"/>
-    <property name="routine_basicAttack" type="bool" value="false"/>
-    <property name="routine_glutton" type="bool" value="true"/>
-    <property name="routine_treasureHunter" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="967" name="Bat" type="Creep" gid="30" x="544" y="608" width="32" height="32">
-   <properties>
-    <property name="Class" value="Bat"/>
-    <property name="routine_prey" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="968" name="Spider" type="Creep" gid="28" x="480" y="608" width="32" height="32">
-   <properties>
-    <property name="Class" value="Spider"/>
-    <property name="routine_defender" type="bool" value="true"/>
-   </properties>
-  </object>
-  <object id="969" name="Goblin" type="Creep" gid="27" x="512" y="576" width="32" height="32">
+ <objectgroup id="8" name="Units">
+  <object id="1360" name="Snob Goblin" type="Creep" gid="27" x="320" y="352" width="32" height="32">
    <properties>
     <property name="Class" value="Goblin"/>
-    <property name="routine_basicAttack" type="bool" value="false"/>
-    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="Independent" type="bool" value="true"/>
+    <property name="Items" value="Door Key"/>
+    <property name="routine_defender" type="bool" value="true"/>
     <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
     <property name="routine_triggerHappy" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="970" name="Troll" type="Creep" gid="22" x="448" y="544" width="32" height="32">
+  <object id="1361" name="Snob Goblin" type="Creep" gid="27" x="736" y="416" width="32" height="32">
    <properties>
-    <property name="Class" value="Troll"/>
+    <property name="Class" value="Goblin"/>
     <property name="Independent" type="bool" value="true"/>
     <property name="routine_defender" type="bool" value="true"/>
-    <property name="routine_kingslayer" type="bool" value="true"/>
     <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+    <property name="routine_triggerHappy" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="972" name="Necromancer" type="Creep" gid="25" x="544" y="512" width="32" height="32">
+  <object id="1362" name="Snob Goblin" type="Creep" gid="27" x="288" y="224" width="32" height="32">
    <properties>
-    <property name="Class" value="Necromancer"/>
-    <property name="Commander" type="bool" value="true"/>
-    <property name="fallback_routine" value="routine_wait"/>
+    <property name="Class" value="Goblin"/>
+    <property name="Independent" type="bool" value="true"/>
     <property name="routine_defender" type="bool" value="true"/>
-    <property name="routine_kingslayer" type="bool" value="true"/>
     <property name="routine_prey" type="bool" value="true"/>
-    <property name="routine_summon" type="bool" value="true"/>
-    <property name="routine_summon.class" value="Skeleton"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+    <property name="routine_triggerHappy" type="bool" value="true"/>
    </properties>
   </object>
  </objectgroup>
- <layer id="4" name="Overlay" width="32" height="20">
+ <objectgroup id="9" name="Disabled" opacity="0.43">
+  <object id="986" name="Spring Trap" type="SpringTrap" gid="6538" x="192" y="64" width="32" height="32">
+   <properties>
+    <property name="trigger.landingCoordinates.x" type="int" value="25"/>
+    <property name="trigger.landingCoordinates.y" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1084" name="Piston Pad W" type="PressurePlate" gid="6670" x="224" y="64" width="32" height="32">
+   <properties>
+    <property name="triggerOnRelease" type="bool" value="false"/>
+    <property name="triggersId" value="Piston W"/>
+   </properties>
+  </object>
+  <object id="1128" name="Launchpad" type="Launchpad" gid="6537" x="160" y="64" width="32" height="32"/>
+  <object id="989" name="Magic Trap" type="Trap" gid="6755" x="384" y="64" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="997" name="Switch E" type="Switch" gid="6597" x="416" y="64" width="32" height="32">
+   <properties>
+    <property name="triggersId" value="Switch Door E"/>
+   </properties>
+  </object>
+  <object id="1155" name="Stalwart Rune" type="BuffTile" gid="6607" x="352" y="64" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1168" name="Power Rune" type="BuffTile" gid="6611" x="288" y="64" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1170" name="Counter Rune" type="BuffTile" gid="6619" x="256" y="64" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1171" name="Fortune Rune" type="BuffTile" gid="6615" x="320" y="64" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <layer id="19" name="Overlay" width="34" height="21">
   <data>
    <tile/>
    <tile/>
@@ -2961,6 +3060,11 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5831"/>
+   <tile gid="5832"/>
+   <tile gid="5832"/>
+   <tile gid="5832"/>
+   <tile gid="5833"/>
    <tile/>
    <tile/>
    <tile/>
@@ -2990,10 +3094,16 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5871"/>
+   <tile gid="5872"/>
+   <tile gid="5872"/>
+   <tile gid="5872"/>
+   <tile gid="5873"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5951"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3005,12 +3115,19 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6037"/>
+   <tile gid="5951"/>
+   <tile gid="6037"/>
+   <tile gid="5926"/>
+   <tile gid="5927"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5928"/>
+   <tile gid="5929"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3020,14 +3137,21 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5991"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6037"/>
+   <tile gid="5951"/>
+   <tile gid="6037"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6071"/>
+   <tile gid="5991"/>
+   <tile gid="6071"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3052,6 +3176,9 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6071"/>
+   <tile gid="5991"/>
+   <tile gid="6071"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3195,7 +3322,9 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="4566"/>
    <tile/>
+   <tile gid="5951"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3209,6 +3338,10 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5831"/>
+   <tile gid="5832"/>
+   <tile gid="5832"/>
+   <tile gid="5833"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3225,6 +3358,7 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5991"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3238,6 +3372,14 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5871"/>
+   <tile gid="5872"/>
+   <tile gid="5872"/>
+   <tile gid="5873"/>
+   <tile gid="5831"/>
+   <tile gid="5832"/>
+   <tile gid="5832"/>
+   <tile gid="5833"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3247,6 +3389,7 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="4809"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3266,6 +3409,11 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6071"/>
+   <tile gid="5871"/>
+   <tile gid="5872"/>
+   <tile gid="5872"/>
+   <tile gid="5873"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3381,6 +3529,7 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5951"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3394,10 +3543,12 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5951"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5951"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3412,6 +3563,7 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5991"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3425,10 +3577,12 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5991"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="5991"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3438,6 +3592,7 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6040"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3471,6 +3626,7 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6071"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3482,6 +3638,23 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5926"/>
+   <tile gid="5927"/>
    <tile/>
    <tile/>
    <tile/>

--- a/SolStandard/Content/TmxMaps/Draft_Hiatok_Fortress.tmx
+++ b/SolStandard/Content/TmxMaps/Draft_Hiatok_Fortress.tmx
@@ -1,0 +1,3459 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="12" nextobjectid="1155">
+ <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
+  <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
+ </tileset>
+ <tileset firstgid="31" source="overworld-32.tsx"/>
+ <tileset firstgid="6311" source="entities-32.tsx"/>
+ <layer id="1" name="Terrain" width="32" height="20">
+  <data>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="191"/>
+   <tile gid="192"/>
+   <tile gid="192"/>
+   <tile gid="192"/>
+   <tile gid="193"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="71"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="231"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="233"/>
+   <tile gid="71"/>
+   <tile gid="72"/>
+   <tile gid="72"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="71"/>
+   <tile gid="72"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="71"/>
+   <tile gid="72"/>
+   <tile gid="72"/>
+   <tile gid="72"/>
+   <tile gid="74"/>
+   <tile gid="75"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="271"/>
+   <tile gid="272"/>
+   <tile gid="34"/>
+   <tile gid="272"/>
+   <tile gid="273"/>
+   <tile gid="151"/>
+   <tile gid="152"/>
+   <tile gid="114"/>
+   <tile gid="113"/>
+   <tile gid="34"/>
+   <tile gid="111"/>
+   <tile gid="115"/>
+   <tile gid="153"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="152"/>
+   <tile gid="152"/>
+   <tile gid="152"/>
+   <tile gid="114"/>
+   <tile gid="112"/>
+   <tile gid="113"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="71"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="33"/>
+   <tile gid="32"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="153"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="153"/>
+   <tile gid="33"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="32"/>
+   <tile gid="34"/>
+   <tile gid="111"/>
+   <tile gid="115"/>
+   <tile gid="155"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="153"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="153"/>
+   <tile gid="151"/>
+   <tile gid="153"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="272"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="71"/>
+   <tile gid="72"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="71"/>
+   <tile gid="72"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="33"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="71"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="152"/>
+   <tile gid="153"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="111"/>
+   <tile gid="115"/>
+   <tile gid="153"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="153"/>
+   <tile gid="33"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="33"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="153"/>
+   <tile gid="272"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="32"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="32"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="32"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="33"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="71"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="153"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="71"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="71"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="71"/>
+   <tile gid="72"/>
+   <tile gid="72"/>
+   <tile gid="72"/>
+   <tile gid="72"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="153"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="111"/>
+   <tile gid="113"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="114"/>
+   <tile gid="112"/>
+   <tile gid="112"/>
+   <tile gid="112"/>
+   <tile gid="113"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="153"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="111"/>
+   <tile gid="112"/>
+   <tile gid="112"/>
+   <tile gid="112"/>
+   <tile gid="113"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="111"/>
+   <tile gid="112"/>
+   <tile gid="112"/>
+   <tile gid="112"/>
+   <tile gid="113"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="152"/>
+   <tile gid="152"/>
+   <tile gid="114"/>
+   <tile gid="75"/>
+   <tile gid="73"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="151"/>
+   <tile gid="152"/>
+   <tile gid="153"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+   <tile gid="34"/>
+  </data>
+ </layer>
+ <layer id="2" name="TerrainDecoration" width="32" height="20">
+  <data>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="83"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="83"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="43"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="83"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="38"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="127"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="127"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="127"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="84"/>
+   <tile gid="87"/>
+   <tile gid="165"/>
+   <tile gid="165"/>
+   <tile gid="165"/>
+   <tile gid="87"/>
+   <tile gid="166"/>
+   <tile/>
+   <tile gid="164"/>
+   <tile gid="87"/>
+   <tile gid="87"/>
+   <tile gid="125"/>
+   <tile gid="165"/>
+   <tile gid="87"/>
+   <tile gid="45"/>
+   <tile gid="126"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="127"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="83"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="167"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="127"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="167"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="127"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="44"/>
+   <tile gid="47"/>
+   <tile gid="47"/>
+   <tile gid="86"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="84"/>
+   <tile gid="165"/>
+   <tile gid="165"/>
+   <tile gid="46"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="124"/>
+   <tile gid="47"/>
+   <tile gid="86"/>
+   <tile/>
+   <tile/>
+   <tile gid="167"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="167"/>
+   <tile/>
+   <tile/>
+   <tile gid="167"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="124"/>
+   <tile gid="47"/>
+   <tile gid="47"/>
+   <tile gid="125"/>
+   <tile gid="47"/>
+   <tile gid="166"/>
+   <tile/>
+   <tile gid="164"/>
+   <tile gid="165"/>
+   <tile gid="87"/>
+   <tile gid="45"/>
+   <tile gid="87"/>
+   <tile gid="166"/>
+   <tile/>
+   <tile gid="164"/>
+   <tile gid="87"/>
+   <tile gid="165"/>
+   <tile gid="125"/>
+   <tile gid="87"/>
+   <tile gid="87"/>
+   <tile gid="126"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="78"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="78"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="78"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="78"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+  </data>
+ </layer>
+ <layer id="3" name="Collide" width="32" height="20">
+  <data>
+   <tile gid="5569"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5568"/>
+   <tile gid="5567"/>
+   <tile gid="239"/>
+   <tile gid="358"/>
+   <tile gid="203"/>
+   <tile gid="240"/>
+   <tile gid="241"/>
+   <tile gid="401"/>
+   <tile gid="281"/>
+   <tile gid="391"/>
+   <tile gid="392"/>
+   <tile gid="393"/>
+   <tile gid="278"/>
+   <tile gid="402"/>
+   <tile gid="91"/>
+   <tile/>
+   <tile gid="278"/>
+   <tile gid="202"/>
+   <tile gid="364"/>
+   <tile gid="202"/>
+   <tile gid="358"/>
+   <tile gid="203"/>
+   <tile gid="240"/>
+   <tile gid="366"/>
+   <tile gid="402"/>
+   <tile gid="278"/>
+   <tile gid="279"/>
+   <tile gid="239"/>
+   <tile gid="239"/>
+   <tile gid="202"/>
+   <tile gid="320"/>
+   <tile gid="240"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="360"/>
+   <tile gid="203"/>
+   <tile gid="240"/>
+   <tile gid="240"/>
+   <tile gid="241"/>
+   <tile gid="448"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="526"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="450"/>
+   <tile gid="91"/>
+   <tile/>
+   <tile/>
+   <tile gid="278"/>
+   <tile gid="279"/>
+   <tile gid="239"/>
+   <tile gid="358"/>
+   <tile/>
+   <tile gid="281"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="278"/>
+   <tile gid="239"/>
+   <tile gid="239"/>
+   <tile gid="202"/>
+   <tile gid="320"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="358"/>
+   <tile gid="240"/>
+   <tile gid="240"/>
+   <tile gid="240"/>
+   <tile gid="241"/>
+   <tile gid="484"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="484"/>
+   <tile gid="132"/>
+   <tile gid="173"/>
+   <tile gid="173"/>
+   <tile gid="54"/>
+   <tile/>
+   <tile gid="278"/>
+   <tile gid="399"/>
+   <tile/>
+   <tile gid="311"/>
+   <tile gid="313"/>
+   <tile gid="438"/>
+   <tile gid="439"/>
+   <tile gid="440"/>
+   <tile/>
+   <tile gid="278"/>
+   <tile gid="239"/>
+   <tile gid="239"/>
+   <tile gid="202"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="358"/>
+   <tile gid="240"/>
+   <tile gid="325"/>
+   <tile gid="240"/>
+   <tile gid="241"/>
+   <tile gid="484"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="528"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="450"/>
+   <tile gid="91"/>
+   <tile gid="448"/>
+   <tile gid="567"/>
+   <tile/>
+   <tile/>
+   <tile gid="391"/>
+   <tile gid="393"/>
+   <tile gid="478"/>
+   <tile/>
+   <tile gid="480"/>
+   <tile gid="444"/>
+   <tile/>
+   <tile gid="238"/>
+   <tile gid="239"/>
+   <tile gid="239"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="358"/>
+   <tile gid="240"/>
+   <tile gid="365"/>
+   <tile gid="240"/>
+   <tile gid="241"/>
+   <tile gid="484"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="484"/>
+   <tile gid="91"/>
+   <tile gid="484"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="484"/>
+   <tile/>
+   <tile gid="278"/>
+   <tile gid="239"/>
+   <tile gid="242"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="320"/>
+   <tile gid="203"/>
+   <tile gid="240"/>
+   <tile gid="240"/>
+   <tile gid="241"/>
+   <tile gid="484"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="524"/>
+   <tile gid="91"/>
+   <tile gid="524"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="484"/>
+   <tile/>
+   <tile/>
+   <tile gid="238"/>
+   <tile gid="239"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="239"/>
+   <tile gid="358"/>
+   <tile gid="203"/>
+   <tile gid="240"/>
+   <tile gid="241"/>
+   <tile gid="528"/>
+   <tile gid="567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="91"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="485"/>
+   <tile gid="566"/>
+   <tile gid="567"/>
+   <tile gid="238"/>
+   <tile gid="202"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="360"/>
+   <tile gid="203"/>
+   <tile gid="240"/>
+   <tile gid="240"/>
+   <tile gid="241"/>
+   <tile gid="516"/>
+   <tile gid="474"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="91"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="524"/>
+   <tile gid="475"/>
+   <tile gid="517"/>
+   <tile gid="238"/>
+   <tile gid="202"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="358"/>
+   <tile gid="240"/>
+   <tile gid="240"/>
+   <tile gid="240"/>
+   <tile gid="241"/>
+   <tile gid="565"/>
+   <tile gid="567"/>
+   <tile/>
+   <tile/>
+   <tile gid="396"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="451"/>
+   <tile gid="267"/>
+   <tile gid="173"/>
+   <tile gid="173"/>
+   <tile gid="54"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="516"/>
+   <tile gid="512"/>
+   <tile gid="513"/>
+   <tile gid="444"/>
+   <tile gid="238"/>
+   <tile gid="239"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="358"/>
+   <tile gid="240"/>
+   <tile gid="240"/>
+   <tile gid="240"/>
+   <tile gid="241"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="511"/>
+   <tile gid="512"/>
+   <tile gid="512"/>
+   <tile gid="474"/>
+   <tile/>
+   <tile gid="491"/>
+   <tile gid="533"/>
+   <tile/>
+   <tile/>
+   <tile gid="91"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="678"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="484"/>
+   <tile gid="238"/>
+   <tile gid="239"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="358"/>
+   <tile gid="203"/>
+   <tile gid="240"/>
+   <tile/>
+   <tile gid="281"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="511"/>
+   <tile gid="512"/>
+   <tile gid="107"/>
+   <tile gid="512"/>
+   <tile gid="512"/>
+   <tile gid="512"/>
+   <tile gid="107"/>
+   <tile gid="512"/>
+   <tile gid="517"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="490"/>
+   <tile gid="278"/>
+   <tile gid="239"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="203"/>
+   <tile gid="243"/>
+   <tile gid="241"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="52"/>
+   <tile gid="173"/>
+   <tile gid="173"/>
+   <tile gid="134"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="91"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="484"/>
+   <tile/>
+   <tile gid="278"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="240"/>
+   <tile gid="240"/>
+   <tile gid="281"/>
+   <tile gid="444"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="91"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="91"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="484"/>
+   <tile/>
+   <tile gid="198"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="240"/>
+   <tile gid="281"/>
+   <tile/>
+   <tile gid="484"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="91"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="91"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="484"/>
+   <tile gid="198"/>
+   <tile gid="239"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="281"/>
+   <tile gid="311"/>
+   <tile gid="313"/>
+   <tile gid="528"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="567"/>
+   <tile gid="91"/>
+   <tile gid="565"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="529"/>
+   <tile gid="566"/>
+   <tile gid="487"/>
+   <tile gid="91"/>
+   <tile gid="565"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="566"/>
+   <tile gid="530"/>
+   <tile gid="238"/>
+   <tile gid="202"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="311"/>
+   <tile gid="314"/>
+   <tile gid="315"/>
+   <tile gid="312"/>
+   <tile gid="312"/>
+   <tile gid="312"/>
+   <tile gid="312"/>
+   <tile gid="312"/>
+   <tile gid="312"/>
+   <tile gid="312"/>
+   <tile gid="313"/>
+   <tile gid="91"/>
+   <tile gid="311"/>
+   <tile gid="313"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="484"/>
+   <tile gid="132"/>
+   <tile gid="54"/>
+   <tile gid="311"/>
+   <tile gid="312"/>
+   <tile gid="312"/>
+   <tile gid="312"/>
+   <tile gid="312"/>
+   <tile gid="312"/>
+   <tile gid="313"/>
+   <tile/>
+   <tile gid="238"/>
+   <tile gid="202"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="391"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="393"/>
+   <tile gid="91"/>
+   <tile gid="391"/>
+   <tile gid="393"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="528"/>
+   <tile gid="567"/>
+   <tile gid="91"/>
+   <tile gid="391"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="392"/>
+   <tile gid="393"/>
+   <tile gid="198"/>
+   <tile gid="202"/>
+   <tile gid="202"/>
+   <tile gid="5565"/>
+   <tile gid="5529"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5528"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+  </data>
+ </layer>
+ <objectgroup id="5" name="Entities">
+  <object id="983" name="Bridge" type="Movable" gid="6372" x="512" y="256" width="32" height="32"/>
+  <object id="985" name="Fort" type="BuffTile" gid="6377" x="320" y="224" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="986" name="Tower" type="BuffTile" gid="563" x="640" y="416" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="987" name="Residence" type="BuffTile" gid="6361" x="704" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="988" name="Fort" type="BuffTile" gid="6378" x="416" y="224" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="989" name="Residence" type="BuffTile" gid="6368" x="448" y="192" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="990" name="Woods" type="BuffTile" gid="357" x="896" y="544" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="991" name="Woods" type="BuffTile" gid="357" x="512" y="416" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="992" name="Woods" type="BuffTile" gid="317" x="352" y="416" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="993" name="Woods" type="BuffTile" gid="317" x="448" y="352" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="994" name="Woods" type="BuffTile" gid="357" x="352" y="288" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="995" name="Tower" type="BuffTile" gid="563" x="608" y="288" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="996" name="Tower" type="BuffTile" gid="563" x="320" y="288" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="997" name="Woods" type="BuffTile" gid="357" x="480" y="96" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="998" name="Woods" type="BuffTile" gid="317" x="448" y="96" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="999" name="Woods" type="BuffTile" gid="357" x="448" y="64" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1001" name="Woods" type="BuffTile" gid="357" x="864" y="224" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1002" name="Woods" type="BuffTile" gid="357" x="864" y="160" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1003" name="Woods" type="BuffTile" gid="317" x="864" y="192" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1004" name="Woods" type="BuffTile" gid="357" x="896" y="224" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1005" name="Woods" type="BuffTile" gid="357" x="832" y="128" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1006" name="Woods" type="BuffTile" gid="357" x="928" y="416" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1007" name="Woods" type="BuffTile" gid="357" x="928" y="448" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1009" name="Woods" type="BuffTile" gid="317" x="544" y="544" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1010" name="Woods" type="BuffTile" gid="317" x="480" y="576" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1011" name="Woods" type="BuffTile" gid="357" x="480" y="544" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1012" name="Woods" type="BuffTile" gid="357" x="672" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1013" name="Woods" type="BuffTile" gid="357" x="672" y="416" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1014" name="Bridge" type="Movable" gid="6372" x="608" y="448" width="32" height="32"/>
+  <object id="1016" name="Bridge" type="Movable" gid="6372" x="384" y="448" width="32" height="32"/>
+  <object id="1018" name="Bridge" type="Movable" gid="6364" x="576" y="320" width="32" height="32"/>
+  <object id="1020" name="Jump" type="Crossing" gid="6866" x="544" y="384" width="32" height="32">
+   <properties>
+    <property name="direction" value="DOWN"/>
+   </properties>
+  </object>
+  <object id="1021" name="Jump" type="Crossing" gid="6866" x="384" y="352" width="32" height="32">
+   <properties>
+    <property name="direction" value="DOWN"/>
+   </properties>
+  </object>
+  <object id="1022" name="Jump" type="Crossing" gid="6866" x="352" y="352" width="32" height="32">
+   <properties>
+    <property name="direction" value="DOWN"/>
+   </properties>
+  </object>
+  <object id="1023" name="Jump" type="Crossing" gid="6866" x="576" y="384" width="32" height="32">
+   <properties>
+    <property name="direction" value="DOWN"/>
+   </properties>
+  </object>
+  <object id="1024" name="Residence" type="BuffTile" gid="6361" x="736" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1025" name="Residence" type="BuffTile" gid="6361" x="768" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1026" name="Residence" type="BuffTile" gid="6361" x="800" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1027" name="Residence" type="BuffTile" gid="6361" x="864" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1028" name="Residence" type="BuffTile" gid="6361" x="832" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1029" name="Residence" type="BuffTile" gid="6361" x="864" y="448" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1030" name="Residence" type="BuffTile" gid="6361" x="864" y="416" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1031" name="Residence" type="BuffTile" gid="6361" x="864" y="384" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1032" name="Residence" type="BuffTile" gid="6361" x="864" y="352" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1033" name="Residence" type="BuffTile" gid="6361" x="832" y="352" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1034" name="Residence" type="BuffTile" gid="6361" x="800" y="352" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1037" name="Residence" type="BuffTile" gid="6360" x="704" y="416" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1038" name="Residence" type="BuffTile" gid="6367" x="704" y="384" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1042" name="Jump" type="Crossing" gid="6865" x="384" y="480" width="32" height="32">
+   <properties>
+    <property name="direction" value="RIGHT"/>
+   </properties>
+  </object>
+  <object id="1043" name="Tower" type="BuffTile" gid="563" x="256" y="224" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1044" name="Fort" type="BuffTile" gid="6378" x="544" y="576" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1045" name="Fort" type="BuffTile" gid="6377" x="320" y="480" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1046" name="Fort" type="BuffTile" gid="6378" x="800" y="256" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1047" name="Fort" type="BuffTile" gid="6377" x="672" y="320" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1048" name="Woods" type="BuffTile" gid="317" x="672" y="352" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1049" name="Woods" type="BuffTile" gid="357" x="640" y="320" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1050" name="Jump" type="Crossing" gid="6867" x="608" y="352" width="32" height="32">
+   <properties>
+    <property name="direction" value="LEFT"/>
+   </properties>
+  </object>
+  <object id="1051" name="Cave W" type="Portal" gid="204" x="128" y="384" width="32" height="32">
+   <properties>
+    <property name="destinationId" value="Cave N"/>
+   </properties>
+  </object>
+  <object id="1052" name="Cave N" type="Portal" gid="204" x="640" y="96" width="32" height="32">
+   <properties>
+    <property name="destinationId" value="Cave W"/>
+   </properties>
+  </object>
+  <object id="1053" name="Woods" type="BuffTile" gid="357" x="352" y="384" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1054" name="Woods" type="BuffTile" gid="357" x="544" y="128" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1055" name="Tower" type="BuffTile" gid="563" x="672" y="224" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1056" name="Tall Tower" type="BuffTile" gid="562" x="224" y="416" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1057" name="Woods" type="BuffTile" gid="357" x="768" y="320" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1058" name="Woods" type="BuffTile" gid="357" x="608" y="160" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1059" name="Woods" type="BuffTile" gid="357" x="192" y="352" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1060" name="Residence" type="BuffTile" gid="6720" x="192" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1061" name="Residence" type="BuffTile" gid="6720" x="224" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1062" name="Residence" type="BuffTile" gid="6720" x="256" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1063" name="Residence" type="BuffTile" gid="6720" x="288" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1064" name="Residence" type="BuffTile" gid="6720" x="320" y="416" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1065" name="Residence" type="BuffTile" gid="6720" x="320" y="384" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1066" name="Residence" type="BuffTile" gid="6719" x="224" y="352" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1067" name="Residence" type="BuffTile" gid="6720" x="160" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1068" name="Residence" type="BuffTile" gid="6721" x="160" y="448" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1069" name="City Hall" type="BuffTile" gid="599" x="288" y="160" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+    <property name="luckBonus" type="int" value="1"/>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1070" name="Woods" type="BuffTile" gid="357" x="320" y="160" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1071" name="Woods" type="BuffTile" gid="357" x="256" y="160" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1072" name="Woods" type="BuffTile" gid="317" x="288" y="128" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1075" name="Woods" type="BuffTile" gid="357" x="704" y="96" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1076" name="Woods" type="BuffTile" gid="357" x="736" y="96" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1077" name="Woods" type="BuffTile" gid="317" x="768" y="96" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1078" name="Woods" type="BuffTile" gid="357" x="800" y="96" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1079" name="Castle" type="BuffTile" gid="479" x="768" y="160" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1080" name="Woods" type="BuffTile" gid="357" x="800" y="192" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1081" name="Woods" type="BuffTile" gid="357" x="800" y="224" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1082" name="Woods" type="BuffTile" gid="357" x="736" y="192" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1083" name="Woods" type="BuffTile" gid="317" x="704" y="192" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1085" name="Woods" type="BuffTile" gid="357" x="576" y="192" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1086" name="Tower" type="BuffTile" gid="563" x="576" y="224" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1087" name="Tower" type="BuffTile" gid="563" x="448" y="320" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1089" name="Woods" type="BuffTile" gid="357" x="416" y="320" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1090" name="Chest Key Vendor" type="Vendor" gid="6527" x="768" y="416" width="32" height="32">
+   <properties>
+    <property name="items" value="Chest Key"/>
+    <property name="prices" value="10"/>
+    <property name="quantities" value="2"/>
+   </properties>
+  </object>
+  <object id="1092" name="Residence" type="BuffTile" gid="6361" x="256" y="256" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1093" name="Residence" type="BuffTile" gid="6719" x="256" y="320" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1094" name="Tower" type="BuffTile" gid="563" x="480" y="480" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1095" name="Residence" type="BuffTile" gid="6361" x="544" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1097" name="Woods" type="BuffTile" gid="357" x="576" y="416" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1098" name="Woods" type="BuffTile" gid="357" x="480" y="288" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1099" name="Woods" type="BuffTile" gid="357" x="544" y="288" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1100" name="Woods" type="BuffTile" gid="357" x="640" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1101" name="Woods" type="BuffTile" gid="357" x="576" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1102" name="Woods" type="BuffTile" gid="357" x="416" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1103" name="Woods" type="BuffTile" gid="357" x="352" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1104" name="Woods" type="BuffTile" gid="317" x="384" y="384" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1106" name="Woods" type="BuffTile" gid="725" x="256" y="416" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1108" name="Rubble" type="BreakableObstacle" gid="6593" x="640" y="160" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="3"/>
+    <property name="gold" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1109" name="Rubble" type="BreakableObstacle" gid="6593" x="160" y="416" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="3"/>
+    <property name="gold" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="959" name="Deploy Blue" type="Deployment" gid="6342" x="704" y="256" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="960" name="Deploy Red" type="Deployment" gid="6350" x="224" y="448" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="973" name="Deploy Blue" type="Deployment" gid="6342" x="768" y="256" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="974" name="Deploy Blue" type="Deployment" gid="6342" x="736" y="256" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="975" name="Deploy Red" type="Deployment" gid="6350" x="288" y="448" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="976" name="Deploy Red" type="Deployment" gid="6350" x="256" y="448" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="977" name="Deploy Red" type="Deployment" gid="6350" x="192" y="448" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="978" name="Deploy Red" type="Deployment" gid="6350" x="192" y="384" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="979" name="Deploy Red" type="Deployment" gid="6350" x="192" y="416" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="980" name="Deploy Blue" type="Deployment" gid="6342" x="736" y="224" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="981" name="Deploy Blue" type="Deployment" gid="6342" x="704" y="224" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="982" name="Deploy Blue" type="Deployment" gid="6342" x="768" y="224" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="1122" name="Jump" type="Crossing" gid="6867" x="512" y="288" width="32" height="32">
+   <properties>
+    <property name="direction" value="LEFT"/>
+   </properties>
+  </object>
+  <object id="1123" name="Jump" type="Crossing" gid="6865" x="608" y="480" width="32" height="32">
+   <properties>
+    <property name="direction" value="RIGHT"/>
+   </properties>
+  </object>
+  <object id="1124" name="Woods" type="BuffTile" gid="317" x="384" y="192" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1125" name="Woods" type="BuffTile" gid="317" x="416" y="192" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1126" name="Woods" type="BuffTile" gid="317" x="448" y="224" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1127" name="Relic Chest" type="Chest" gid="6545" x="608" y="192" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+    <property name="itemPool" value="Relics"/>
+   </properties>
+  </object>
+  <object id="1128" name="Relic Chest" type="Chest" gid="6545" x="448" y="480" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+    <property name="itemPool" value="Relics"/>
+   </properties>
+  </object>
+  <object id="1129" name="Relic Chest" type="Chest" gid="6545" x="384" y="224" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+    <property name="itemPool" value="Relics"/>
+   </properties>
+  </object>
+  <object id="1130" name="Relic Chest" type="Chest" gid="6545" x="800" y="416" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+    <property name="itemPool" value="Relics"/>
+   </properties>
+  </object>
+  <object id="1131" name="Relic Chest" type="Chest" gid="6545" x="512" y="352" width="32" height="32">
+   <properties>
+    <property name="isLocked" type="bool" value="true"/>
+    <property name="itemPool" value="Relics"/>
+   </properties>
+  </object>
+  <object id="1154" name="Woods" type="BuffTile" gid="357" x="96" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="6" name="Loot" opacity="0.75">
+  <object id="1120" name="Free Contract" type="Contract" gid="6471" x="288" y="128" width="32" height="32">
+   <properties>
+    <property name="forSpecificUnit" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1132" name="Ruby Relic" type="Relic" gid="6523" x="448" y="32" width="32" height="32">
+   <properties>
+    <property name="itemPool" value="Relics"/>
+   </properties>
+  </object>
+  <object id="1133" name="Sapphire Relic" type="Relic" gid="6447" x="480" y="32" width="32" height="32">
+   <properties>
+    <property name="itemPool" value="Relics"/>
+   </properties>
+  </object>
+  <object id="1134" name="Heart Relic" type="Relic" gid="6455" x="544" y="32" width="32" height="32">
+   <properties>
+    <property name="itemPool" value="Relics"/>
+   </properties>
+  </object>
+  <object id="1135" name="Emerald Relic" type="Relic" gid="6511" x="512" y="32" width="32" height="32">
+   <properties>
+    <property name="itemPool" value="Relics"/>
+   </properties>
+  </object>
+  <object id="1136" name="Amber Relic" type="Relic" gid="6515" x="576" y="32" width="32" height="32">
+   <properties>
+    <property name="itemPool" value="Relics"/>
+   </properties>
+  </object>
+  <object id="1137" name="Chest Key" type="Key" gid="6399" x="768" y="384" width="32" height="32">
+   <properties>
+    <property name="usedWith" value="Relic Chest"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="11" name="Summons" opacity="0.69">
+  <object id="961" name="Slime" type="Creep" gid="21" x="32" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="971" name="Skeleton" type="Creep" gid="26" x="0" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="7" name="Items">
+  <object id="1138" name="Emerald" type="Currency" gid="6784" x="384" y="256" width="32" height="32">
+   <properties>
+    <property name="value" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1139" name="Sapphire" type="Currency" gid="6785" x="544" y="352" width="32" height="32">
+   <properties>
+    <property name="value" type="int" value="20"/>
+   </properties>
+  </object>
+  <object id="1141" name="Emerald" type="Currency" gid="6784" x="640" y="256" width="32" height="32">
+   <properties>
+    <property name="value" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1143" name="Emerald" type="Currency" gid="6784" x="736" y="384" width="32" height="32">
+   <properties>
+    <property name="value" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1144" name="Emerald" type="Currency" gid="6784" x="832" y="384" width="32" height="32">
+   <properties>
+    <property name="value" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1145" name="Emerald" type="Currency" gid="6784" x="832" y="448" width="32" height="32">
+   <properties>
+    <property name="value" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1146" name="Emerald" type="Currency" gid="6784" x="736" y="448" width="32" height="32">
+   <properties>
+    <property name="value" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1147" name="Emerald" type="Currency" gid="6784" x="288" y="384" width="32" height="32">
+   <properties>
+    <property name="value" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1149" name="Emerald" type="Currency" gid="6784" x="448" y="448" width="32" height="32">
+   <properties>
+    <property name="value" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1150" name="Emerald" type="Currency" gid="6784" x="576" y="448" width="32" height="32">
+   <properties>
+    <property name="value" type="int" value="10"/>
+   </properties>
+  </object>
+  <object id="1153" name="Emerald" type="Currency" gid="6784" x="352" y="320" width="32" height="32">
+   <properties>
+    <property name="value" type="int" value="10"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="8" name="Units">
+  <object id="963" name="Slime" type="Creep" gid="21" x="640" y="288" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="gold" type="int" value="3"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="972" name="Necromancer" type="Creep" gid="25" x="288" y="160" width="32" height="32">
+   <properties>
+    <property name="Class" value="Necromancer"/>
+    <property name="Commander" type="bool" value="true"/>
+    <property name="Items" value="Free Contract"/>
+    <property name="fallback_routine" value="routine_wait"/>
+    <property name="gold" type="int" value="20"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Skeleton"/>
+   </properties>
+  </object>
+  <object id="1110" name="Slime" type="Creep" gid="21" x="544" y="448" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="gold" type="int" value="3"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1111" name="Orc" type="Creep" gid="23" x="416" y="448" width="32" height="32">
+   <properties>
+    <property name="Class" value="Orc"/>
+    <property name="Items" value="Chest Key"/>
+    <property name="gold" type="int" value="10"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1112" name="Orc" type="Creep" gid="23" x="736" y="352" width="32" height="32">
+   <properties>
+    <property name="Class" value="Orc"/>
+    <property name="gold" type="int" value="10"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1113" name="Orc" type="Creep" gid="23" x="576" y="288" width="32" height="32">
+   <properties>
+    <property name="Class" value="Orc"/>
+    <property name="Items" value="Chest Key"/>
+    <property name="gold" type="int" value="0"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1115" name="Skeleton" type="Creep" gid="26" x="288" y="256" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="3"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1117" name="Skeleton" type="Creep" gid="26" x="256" y="256" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1118" name="Slime" type="Creep" gid="21" x="480" y="256" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1119" name="Goblin" type="Creep" gid="27" x="384" y="288" width="32" height="32">
+   <properties>
+    <property name="Class" value="Goblin"/>
+    <property name="Items" value="Chest Key"/>
+    <property name="gold" type="int" value="15"/>
+    <property name="routine_basicAttack" type="bool" value="false"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_triggerHappy" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1121" name="Skeleton" type="Creep" gid="26" x="320" y="224" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="9" name="Disabled" opacity="0.24"/>
+ <layer id="4" name="Overlay" width="32" height="20">
+  <data>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="6319"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="6319"/>
+   <tile/>
+   <tile/>
+   <tile gid="6319"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="6319"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="6319"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="6319"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="454"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="495"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="522"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="6319"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="6319"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+  </data>
+ </layer>
+</map>

--- a/SolStandard/Content/TmxMaps/Draft_Hiatok_Fortress.tmx
+++ b/SolStandard/Content/TmxMaps/Draft_Hiatok_Fortress.tmx
@@ -2387,7 +2387,7 @@
   <object id="1090" name="Chest Key Vendor" type="Vendor" gid="6527" x="768" y="416" width="32" height="32">
    <properties>
     <property name="items" value="Chest Key"/>
-    <property name="prices" value="10"/>
+    <property name="prices" value="15"/>
     <property name="quantities" value="2"/>
    </properties>
   </object>
@@ -2458,13 +2458,13 @@
   </object>
   <object id="1108" name="Rubble" type="BreakableObstacle" gid="6593" x="640" y="160" width="32" height="32">
    <properties>
-    <property name="HP" type="int" value="3"/>
+    <property name="HP" type="int" value="2"/>
     <property name="gold" type="int" value="10"/>
    </properties>
   </object>
   <object id="1109" name="Rubble" type="BreakableObstacle" gid="6593" x="160" y="416" width="32" height="32">
    <properties>
-    <property name="HP" type="int" value="3"/>
+    <property name="HP" type="int" value="2"/>
     <property name="gold" type="int" value="10"/>
    </properties>
   </object>
@@ -2783,7 +2783,7 @@
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1118" name="Slime" type="Creep" gid="21" x="480" y="256" width="32" height="32">
+  <object id="1118" name="Slime" type="Creep" gid="21" x="448" y="256" width="32" height="32">
    <properties>
     <property name="Class" value="Slime"/>
     <property name="routine_glutton" type="bool" value="true"/>

--- a/SolStandard/Content/TmxMaps/Draft_Hiatok_Fortress.tmx
+++ b/SolStandard/Content/TmxMaps/Draft_Hiatok_Fortress.tmx
@@ -2589,7 +2589,7 @@
    </properties>
   </object>
  </objectgroup>
- <objectgroup id="6" name="Loot" opacity="0.75">
+ <objectgroup id="6" name="Loot" opacity="0.63">
   <object id="1120" name="Free Contract" type="Contract" gid="6471" x="288" y="128" width="32" height="32">
    <properties>
     <property name="forSpecificUnit" type="bool" value="false"/>

--- a/SolStandard/Content/TmxMaps/Draft_Quest_Race.tmx
+++ b/SolStandard/Content/TmxMaps/Draft_Quest_Race.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="22" tilewidth="32" tileheight="32" infinite="0" nextlayerid="16" nextobjectid="1200">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="22" tilewidth="32" tileheight="32" infinite="0" nextlayerid="16" nextobjectid="1204">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -2332,17 +2332,11 @@
   </object>
   <object id="1048" name="Castle" type="BuffTile" gid="6352" x="896" y="96" width="32" height="32">
    <properties>
-    <property name="atkBonus" type="int" value="1"/>
-    <property name="blockBonus" type="int" value="2"/>
-    <property name="luckBonus" type="int" value="1"/>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
   <object id="1049" name="Castle" type="BuffTile" gid="6355" x="96" y="96" width="32" height="32">
    <properties>
-    <property name="atkBonus" type="int" value="1"/>
-    <property name="blockBonus" type="int" value="2"/>
-    <property name="luckBonus" type="int" value="1"/>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
@@ -2524,7 +2518,7 @@
     <property name="HP" type="int" value="2"/>
    </properties>
   </object>
-  <object id="959" name="Deploy Blue" type="Deployment" gid="6342" x="96" y="320" width="32" height="32">
+  <object id="959" name="Deploy Blue" type="Deployment" gid="6342" x="128" y="320" width="32" height="32">
    <properties>
     <property name="Team" value="Blue"/>
    </properties>
@@ -2564,12 +2558,12 @@
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="976" name="Deploy Red" type="Deployment" gid="6350" x="896" y="352" width="32" height="32">
+  <object id="976" name="Deploy Red" type="Deployment" gid="6350" x="896" y="320" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="977" name="Deploy Red" type="Deployment" gid="6350" x="896" y="320" width="32" height="32">
+  <object id="977" name="Deploy Red" type="Deployment" gid="6350" x="864" y="352" width="32" height="32">
    <properties>
     <property name="Team" value="Red"/>
    </properties>
@@ -3069,6 +3063,10 @@
     <property name="range" type="int" value="20"/>
    </properties>
   </object>
+  <object id="1200" name="Castle Drawbridge" type="Drawbridge" gid="6364" x="64" y="128" width="32" height="32"/>
+  <object id="1201" name="Castle Drawbridge" type="Drawbridge" gid="6364" x="128" y="128" width="32" height="32"/>
+  <object id="1202" name="Castle Drawbridge" type="Drawbridge" gid="6364" x="864" y="128" width="32" height="32"/>
+  <object id="1203" name="Castle Drawbridge" type="Drawbridge" gid="6364" x="928" y="128" width="32" height="32"/>
  </objectgroup>
  <objectgroup id="6" name="Loot" opacity="0.75">
   <object id="995" name="Battle Axe" type="Weapon" gid="6803" x="704" y="32" width="32" height="32">

--- a/SolStandard/Content/TmxMaps/Draft_Quest_Race.tmx
+++ b/SolStandard/Content/TmxMaps/Draft_Quest_Race.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="22" tilewidth="32" tileheight="32" infinite="0" nextlayerid="16" nextobjectid="1196">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="22" tilewidth="32" tileheight="32" infinite="0" nextlayerid="16" nextobjectid="1200">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -2288,7 +2288,7 @@
     <property name="range" type="int" value="20"/>
    </properties>
   </object>
-  <object id="1025" name="Ballista" type="Railgun" gid="6733" x="352" y="224" width="32" height="32">
+  <object id="1025" name="Ballista" type="Railgun" gid="6733" x="352" y="256" width="32" height="32">
    <properties>
     <property name="range" type="int" value="20"/>
    </properties>
@@ -2946,7 +2946,7 @@
     <property name="range" value="5,6"/>
    </properties>
   </object>
-  <object id="1179" name="Ensnaring Trap" type="Trap" gid="6741" x="320" y="256" width="32" height="32">
+  <object id="1179" name="Ensnaring Trap" type="Trap" gid="6741" x="320" y="224" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="limitedTriggers" type="bool" value="true"/>
@@ -3047,6 +3047,26 @@
   <object id="1195" name="Tower" type="BuffTile" gid="6327" x="864" y="576" width="32" height="32">
    <properties>
     <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1196" name="Ballista" type="Railgun" gid="6733" x="736" y="224" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="20"/>
+   </properties>
+  </object>
+  <object id="1197" name="Ballista" type="Railgun" gid="6733" x="224" y="224" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="20"/>
+   </properties>
+  </object>
+  <object id="1198" name="Ballista" type="Railgun" gid="6733" x="544" y="96" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="20"/>
+   </properties>
+  </object>
+  <object id="1199" name="Ballista" type="Railgun" gid="6733" x="224" y="128" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="20"/>
    </properties>
   </object>
  </objectgroup>

--- a/SolStandard/Content/TmxMaps/Draft_Quest_Race.tmx
+++ b/SolStandard/Content/TmxMaps/Draft_Quest_Race.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="12" nextobjectid="1188">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="22" tilewidth="32" tileheight="32" infinite="0" nextlayerid="16" nextobjectid="1196">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
  <tileset firstgid="31" source="overworld-32.tsx"/>
  <tileset firstgid="6311" source="entities-32.tsx"/>
- <layer id="1" name="Terrain" width="32" height="20">
+ <layer id="12" name="Terrain" width="32" height="22">
   <data>
    <tile gid="1551"/>
    <tile gid="1551"/>
@@ -647,9 +647,73 @@
    <tile gid="1551"/>
    <tile gid="1551"/>
    <tile gid="1551"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
   </data>
  </layer>
- <layer id="2" name="TerrainDecoration" width="32" height="20">
+ <layer id="13" name="TerrainDecoration" width="32" height="22">
   <data>
    <tile/>
    <tile/>
@@ -1291,9 +1355,73 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
   </data>
  </layer>
- <layer id="3" name="Collide" width="32" height="20">
+ <layer id="14" name="Collide" width="32" height="22">
   <data>
    <tile gid="5569"/>
    <tile gid="5606"/>
@@ -1935,6 +2063,70 @@
    <tile gid="5566"/>
    <tile gid="5566"/>
    <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
   </data>
  </layer>
  <objectgroup id="5" name="Entities">
@@ -1948,17 +2140,17 @@
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="985" name="Residence" type="BuffTile" gid="6361" x="320" y="480" width="32" height="32">
+  <object id="985" name="Residence" type="BuffTile" gid="6359" x="320" y="480" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="986" name="Fort" type="BuffTile" gid="6378" x="224" y="512" width="32" height="32">
+  <object id="986" name="Fort" type="BuffTile" gid="6378" x="384" y="480" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="987" name="Residence" type="BuffTile" gid="6368" x="256" y="544" width="32" height="32">
+  <object id="987" name="Residence" type="BuffTile" gid="6368" x="288" y="544" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
@@ -2017,7 +2209,7 @@
     <property name="range" value="5,6"/>
    </properties>
   </object>
-  <object id="1003" name="Ballista" type="Railgun" gid="6733" x="384" y="416" width="32" height="32">
+  <object id="1003" name="Ballista" type="Railgun" gid="6733" x="320" y="448" width="32" height="32">
    <properties>
     <property name="range" type="int" value="20"/>
    </properties>
@@ -2113,7 +2305,7 @@
     <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1033" name="Residence" type="BuffTile" gid="6361" x="800" y="544" width="32" height="32">
+  <object id="1033" name="Residence" type="BuffTile" gid="6359" x="800" y="544" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
@@ -2257,7 +2449,7 @@
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1092" name="Woods" type="BuffTile" gid="1877" x="352" y="544" width="32" height="32">
+  <object id="1092" name="Woods" type="BuffTile" gid="1877" x="352" y="512" width="32" height="32">
    <properties>
     <property name="luckBonus" type="int" value="1"/>
    </properties>
@@ -2307,7 +2499,7 @@
     <property name="luckBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1102" name="Residence" type="BuffTile" gid="6361" x="672" y="512" width="32" height="32">
+  <object id="1102" name="Residence" type="BuffTile" gid="6367" x="672" y="512" width="32" height="32">
    <properties>
     <property name="retBonus" type="int" value="1"/>
    </properties>
@@ -2392,26 +2584,26 @@
     <property name="Team" value="Red"/>
    </properties>
   </object>
-  <object id="1108" name="Magic Trap" type="Trap" gid="6755" x="96" y="480" width="32" height="32">
+  <object id="1108" name="Magic Trap" type="Trap" gid="6755" x="128" y="544" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="5"/>
     <property name="limitedTriggers" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1109" name="Magic Trap" type="Trap" gid="6755" x="896" y="544" width="32" height="32">
+  <object id="1109" name="Magic Trap" type="Trap" gid="6755" x="736" y="576" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="5"/>
     <property name="limitedTriggers" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1110" name="Ensnaring Trap" type="Trap" gid="6741" x="256" y="512" width="32" height="32">
+  <object id="1110" name="Ensnaring Trap" type="Trap" gid="6741" x="224" y="448" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="limitedTriggers" type="bool" value="true"/>
     <property name="willSnare" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1111" name="Fire Trap" type="Trap" gid="6747" x="864" y="512" width="32" height="32">
+  <object id="1111" name="Fire Trap" type="Trap" gid="6747" x="800" y="448" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="limitedTriggers" type="bool" value="false"/>
@@ -2443,7 +2635,7 @@
     <property name="HP" type="int" value="2"/>
    </properties>
   </object>
-  <object id="1119" name="Ensnaring Trap" type="Trap" gid="6741" x="288" y="448" width="32" height="32">
+  <object id="1119" name="Ensnaring Trap" type="Trap" gid="6741" x="288" y="480" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="limitedTriggers" type="bool" value="true"/>
@@ -2464,7 +2656,7 @@
     <property name="willSnare" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1122" name="Ensnaring Trap" type="Trap" gid="6741" x="736" y="576" width="32" height="32">
+  <object id="1122" name="Ensnaring Trap" type="Trap" gid="6741" x="704" y="576" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="limitedTriggers" type="bool" value="true"/>
@@ -2512,12 +2704,12 @@
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1130" name="Fort" type="BuffTile" gid="6378" x="96" y="544" width="32" height="32">
+  <object id="1130" name="Fort" type="BuffTile" gid="6378" x="192" y="576" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1131" name="Fort" type="BuffTile" gid="6377" x="128" y="576" width="32" height="32">
+  <object id="1131" name="Fort" type="BuffTile" gid="6377" x="96" y="480" width="32" height="32">
    <properties>
     <property name="blockBonus" type="int" value="1"/>
    </properties>
@@ -2726,7 +2918,7 @@
     <property name="willSnare" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1174" name="Fire Trap" type="Trap" gid="6747" x="288" y="480" width="32" height="32">
+  <object id="1174" name="Fire Trap" type="Trap" gid="6747" x="384" y="448" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="3"/>
     <property name="limitedTriggers" type="bool" value="false"/>
@@ -2788,7 +2980,7 @@
     <property name="item" value="Health Potion"/>
    </properties>
   </object>
-  <object id="1186" name="Ballista" type="Railgun" gid="6733" x="224" y="448" width="32" height="32">
+  <object id="1186" name="Ballista" type="Railgun" gid="6733" x="256" y="512" width="32" height="32">
    <properties>
     <property name="range" type="int" value="20"/>
    </properties>
@@ -2805,7 +2997,7 @@
     <property name="retBonus" type="int" value="1"/>
    </properties>
   </object>
-  <object id="1140" name="Magic Trap" type="Trap" gid="6755" x="352" y="512" width="32" height="32">
+  <object id="1140" name="Magic Trap" type="Trap" gid="6755" x="384" y="544" width="32" height="32">
    <properties>
     <property name="damage" type="int" value="5"/>
     <property name="limitedTriggers" type="bool" value="true"/>
@@ -2815,6 +3007,46 @@
    <properties>
     <property name="damage" type="int" value="5"/>
     <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1188" name="Woods" type="BuffTile" gid="1877" x="768" y="576" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1189" name="Tower" type="BuffTile" gid="6327" x="800" y="512" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1190" name="Tower" type="BuffTile" gid="6327" x="736" y="480" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1191" name="Tower" type="BuffTile" gid="6327" x="224" y="512" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1192" name="Tower" type="BuffTile" gid="6327" x="352" y="544" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1193" name="Tower" type="BuffTile" gid="6327" x="320" y="416" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1194" name="Woods" type="BuffTile" gid="1877" x="352" y="416" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1195" name="Tower" type="BuffTile" gid="6327" x="864" y="576" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
    </properties>
   </object>
  </objectgroup>
@@ -2870,21 +3102,21 @@
  </objectgroup>
  <objectgroup id="7" name="Items"/>
  <objectgroup id="8" name="Units">
-  <object id="1028" name="Skeleton" type="Creep" gid="26" x="320" y="448" width="32" height="32">
+  <object id="1028" name="Skeleton" type="Creep" gid="26" x="384" y="512" width="32" height="32">
    <properties>
     <property name="Class" value="Skeleton"/>
     <property name="gold" type="int" value="5"/>
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1029" name="Skeleton" type="Creep" gid="26" x="736" y="480" width="32" height="32">
+  <object id="1029" name="Skeleton" type="Creep" gid="26" x="704" y="480" width="32" height="32">
    <properties>
     <property name="Class" value="Skeleton"/>
     <property name="gold" type="int" value="5"/>
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1038" name="Skeleton" type="Creep" gid="26" x="800" y="448" width="32" height="32">
+  <object id="1038" name="Skeleton" type="Creep" gid="26" x="832" y="480" width="32" height="32">
    <properties>
     <property name="Class" value="Skeleton"/>
     <property name="gold" type="int" value="5"/>
@@ -2898,14 +3130,14 @@
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1040" name="Skeleton" type="Creep" gid="26" x="800" y="512" width="32" height="32">
+  <object id="1040" name="Skeleton" type="Creep" gid="26" x="736" y="416" width="32" height="32">
    <properties>
     <property name="Class" value="Skeleton"/>
     <property name="gold" type="int" value="5"/>
     <property name="routine_defender" type="bool" value="true"/>
    </properties>
   </object>
-  <object id="1041" name="Skeleton" type="Creep" gid="26" x="192" y="480" width="32" height="32">
+  <object id="1041" name="Skeleton" type="Creep" gid="26" x="256" y="544" width="32" height="32">
    <properties>
     <property name="Class" value="Skeleton"/>
     <property name="gold" type="int" value="5"/>
@@ -3085,7 +3317,7 @@
    </properties>
   </object>
  </objectgroup>
- <layer id="4" name="Overlay" width="32" height="20">
+ <layer id="15" name="Overlay" width="32" height="22">
   <data>
    <tile/>
    <tile/>
@@ -3122,16 +3354,31 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3511"/>
+   <tile gid="3512"/>
+   <tile gid="3513"/>
+   <tile gid="3711"/>
+   <tile gid="3712"/>
+   <tile gid="3713"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3511"/>
+   <tile gid="3512"/>
+   <tile gid="3513"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3511"/>
+   <tile gid="3512"/>
+   <tile gid="3513"/>
    <tile/>
    <tile/>
+   <tile gid="3711"/>
+   <tile gid="3712"/>
+   <tile gid="3713"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3139,6 +3386,9 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3551"/>
+   <tile gid="3552"/>
+   <tile gid="3553"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3146,10 +3396,16 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3551"/>
+   <tile gid="3552"/>
+   <tile gid="3553"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3551"/>
+   <tile gid="3552"/>
+   <tile gid="3553"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3164,7 +3420,6 @@
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="387"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3179,6 +3434,7 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6319"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3187,8 +3443,14 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3751"/>
+   <tile gid="3752"/>
+   <tile gid="3753"/>
    <tile/>
    <tile/>
+   <tile gid="3751"/>
+   <tile gid="3752"/>
+   <tile gid="3753"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3196,40 +3458,10 @@
    <tile/>
    <tile/>
    <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
+   <tile gid="6319"/>
+   <tile gid="3511"/>
+   <tile gid="3512"/>
+   <tile gid="3513"/>
    <tile gid="2015"/>
    <tile/>
    <tile/>
@@ -3243,6 +3475,30 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3791"/>
+   <tile gid="3792"/>
+   <tile gid="3793"/>
+   <tile/>
+   <tile/>
+   <tile gid="3791"/>
+   <tile gid="3792"/>
+   <tile gid="3793"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="3551"/>
+   <tile gid="3552"/>
+   <tile gid="3553"/>
+   <tile/>
+   <tile/>
+   <tile gid="3751"/>
+   <tile gid="3752"/>
+   <tile gid="3753"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3272,6 +3528,102 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3791"/>
+   <tile gid="3792"/>
+   <tile gid="3793"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="3591"/>
+   <tile gid="3592"/>
+   <tile gid="3593"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="3591"/>
+   <tile gid="3592"/>
+   <tile gid="3593"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="3631"/>
+   <tile gid="3632"/>
+   <tile gid="3633"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="3631"/>
+   <tile gid="3632"/>
+   <tile gid="3633"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="3511"/>
+   <tile gid="3512"/>
+   <tile gid="3513"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3293,10 +3645,17 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile/>
+   <tile gid="3591"/>
+   <tile gid="3592"/>
+   <tile gid="3593"/>
    <tile/>
    <tile/>
    <tile/>
    <tile gid="1975"/>
+   <tile gid="3551"/>
+   <tile gid="3552"/>
+   <tile gid="3553"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3313,9 +3672,16 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3671"/>
+   <tile gid="3672"/>
+   <tile gid="3673"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3631"/>
+   <tile gid="3632"/>
+   <tile gid="3633"/>
+   <tile gid="6319"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3334,12 +3700,18 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3751"/>
+   <tile gid="3752"/>
    <tile/>
    <tile/>
+   <tile gid="3711"/>
+   <tile gid="3712"/>
+   <tile gid="3713"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6319"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3349,11 +3721,19 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3591"/>
+   <tile gid="3592"/>
+   <tile gid="3593"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3591"/>
+   <tile gid="3592"/>
+   <tile gid="3593"/>
    <tile/>
    <tile/>
+   <tile gid="3791"/>
+   <tile gid="3792"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3368,10 +3748,20 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3511"/>
+   <tile gid="3512"/>
+   <tile gid="3513"/>
    <tile/>
    <tile/>
+   <tile gid="3631"/>
+   <tile gid="3632"/>
+   <tile gid="3633"/>
    <tile/>
    <tile/>
+   <tile gid="6319"/>
+   <tile gid="3631"/>
+   <tile gid="3632"/>
+   <tile gid="3633"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3384,173 +3774,15 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6319"/>
+   <tile gid="3591"/>
+   <tile gid="3592"/>
+   <tile gid="3593"/>
    <tile/>
    <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile gid="1975"/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
-   <tile/>
+   <tile gid="3551"/>
+   <tile gid="3552"/>
+   <tile gid="3553"/>
    <tile gid="387"/>
    <tile/>
    <tile/>
@@ -3560,6 +3792,7 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6319"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3574,6 +3807,10 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3631"/>
+   <tile gid="3632"/>
+   <tile gid="3633"/>
+   <tile gid="6319"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3584,6 +3821,7 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6319"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3594,6 +3832,9 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3751"/>
+   <tile gid="3752"/>
+   <tile gid="3753"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3606,6 +3847,9 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3751"/>
+   <tile gid="3752"/>
+   <tile gid="3753"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3614,11 +3858,15 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="6319"/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3791"/>
+   <tile gid="3792"/>
+   <tile gid="3793"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3631,9 +3879,15 @@
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3791"/>
+   <tile gid="3792"/>
+   <tile gid="3793"/>
    <tile/>
    <tile/>
    <tile/>
+   <tile gid="3591"/>
+   <tile gid="3592"/>
+   <tile gid="3593"/>
    <tile/>
    <tile/>
    <tile/>
@@ -3648,7 +3902,49 @@
    <tile/>
    <tile/>
    <tile/>
-   <tile gid="427"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
    <tile/>
    <tile/>
    <tile/>

--- a/SolStandard/Content/TmxMaps/Draft_Quest_Race.tmx
+++ b/SolStandard/Content/TmxMaps/Draft_Quest_Race.tmx
@@ -1,0 +1,3732 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="32" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="12" nextobjectid="1188">
+ <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
+  <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
+ </tileset>
+ <tileset firstgid="31" source="overworld-32.tsx"/>
+ <tileset firstgid="6311" source="entities-32.tsx"/>
+ <layer id="1" name="Terrain" width="32" height="20">
+  <data>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1553"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1553"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1552"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1553"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1552"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1553"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1553"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1552"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1552"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1553"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1553"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1552"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1553"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1552"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1552"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1553"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1552"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1552"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1552"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1552"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+   <tile gid="1551"/>
+  </data>
+ </layer>
+ <layer id="2" name="TerrainDecoration" width="32" height="20">
+  <data>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile gid="832"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+  </data>
+ </layer>
+ <layer id="3" name="Collide" width="32" height="20">
+  <data>
+   <tile gid="5569"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5606"/>
+   <tile gid="5568"/>
+   <tile gid="5567"/>
+   <tile gid="1611"/>
+   <tile gid="6346"/>
+   <tile gid="6347"/>
+   <tile gid="6348"/>
+   <tile gid="1611"/>
+   <tile gid="444"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2011"/>
+   <tile gid="2012"/>
+   <tile gid="2012"/>
+   <tile gid="2013"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1798"/>
+   <tile gid="1919"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1991"/>
+   <tile gid="444"/>
+   <tile gid="1611"/>
+   <tile gid="6343"/>
+   <tile gid="6344"/>
+   <tile gid="6345"/>
+   <tile gid="1611"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="1611"/>
+   <tile gid="6354"/>
+   <tile/>
+   <tile gid="6356"/>
+   <tile gid="1611"/>
+   <tile gid="484"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2011"/>
+   <tile gid="2012"/>
+   <tile gid="2012"/>
+   <tile gid="2013"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1991"/>
+   <tile gid="484"/>
+   <tile gid="1611"/>
+   <tile gid="6351"/>
+   <tile/>
+   <tile gid="6353"/>
+   <tile gid="1611"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="1652"/>
+   <tile gid="1693"/>
+   <tile gid="1693"/>
+   <tile gid="1693"/>
+   <tile gid="1654"/>
+   <tile gid="484"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2051"/>
+   <tile gid="2014"/>
+   <tile gid="2012"/>
+   <tile gid="1975"/>
+   <tile gid="1973"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1881"/>
+   <tile gid="1882"/>
+   <tile/>
+   <tile gid="1991"/>
+   <tile gid="484"/>
+   <tile gid="1652"/>
+   <tile gid="1693"/>
+   <tile gid="1693"/>
+   <tile gid="1693"/>
+   <tile gid="1654"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="565"/>
+   <tile gid="530"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2011"/>
+   <tile gid="2012"/>
+   <tile gid="2012"/>
+   <tile gid="1975"/>
+   <tile gid="1693"/>
+   <tile gid="1574"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1921"/>
+   <tile gid="1922"/>
+   <tile/>
+   <tile gid="2031"/>
+   <tile gid="528"/>
+   <tile gid="567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="565"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1881"/>
+   <tile gid="1882"/>
+   <tile/>
+   <tile/>
+   <tile gid="2051"/>
+   <tile gid="1667"/>
+   <tile gid="2052"/>
+   <tile gid="2053"/>
+   <tile gid="2036"/>
+   <tile gid="1627"/>
+   <tile gid="2037"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="5839"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1921"/>
+   <tile gid="1922"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1611"/>
+   <tile gid="1877"/>
+   <tile gid="1831"/>
+   <tile gid="1833"/>
+   <tile gid="2011"/>
+   <tile gid="1973"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="6318"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="5879"/>
+   <tile gid="5918"/>
+   <tile gid="5919"/>
+   <tile gid="5918"/>
+   <tile gid="5919"/>
+   <tile gid="5838"/>
+   <tile gid="5839"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1611"/>
+   <tile gid="1831"/>
+   <tile gid="1914"/>
+   <tile gid="1913"/>
+   <tile gid="1774"/>
+   <tile gid="1975"/>
+   <tile gid="1973"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="6318"/>
+   <tile gid="2036"/>
+   <tile gid="2114"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5878"/>
+   <tile gid="5879"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1611"/>
+   <tile gid="1911"/>
+   <tile gid="1913"/>
+   <tile gid="1837"/>
+   <tile gid="2171"/>
+   <tile gid="2134"/>
+   <tile gid="2013"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="444"/>
+   <tile gid="2031"/>
+   <tile gid="2152"/>
+   <tile gid="2152"/>
+   <tile gid="2152"/>
+   <tile gid="2152"/>
+   <tile gid="2152"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5918"/>
+   <tile gid="5919"/>
+   <tile/>
+   <tile gid="1917"/>
+   <tile/>
+   <tile/>
+   <tile gid="2036"/>
+   <tile gid="1627"/>
+   <tile gid="2037"/>
+   <tile gid="1831"/>
+   <tile gid="1833"/>
+   <tile gid="2036"/>
+   <tile gid="1734"/>
+   <tile gid="1975"/>
+   <tile gid="1973"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="528"/>
+   <tile gid="450"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2115"/>
+   <tile gid="2152"/>
+   <tile gid="2152"/>
+   <tile gid="2153"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2011"/>
+   <tile gid="1973"/>
+   <tile gid="1911"/>
+   <tile gid="1915"/>
+   <tile gid="1833"/>
+   <tile gid="2051"/>
+   <tile gid="2014"/>
+   <tile gid="1787"/>
+   <tile gid="1693"/>
+   <tile gid="1693"/>
+   <tile gid="1693"/>
+   <tile gid="1574"/>
+   <tile gid="524"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile gid="2152"/>
+   <tile gid="2037"/>
+   <tile/>
+   <tile/>
+   <tile gid="2036"/>
+   <tile gid="2153"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2011"/>
+   <tile gid="1975"/>
+   <tile gid="1973"/>
+   <tile gid="1911"/>
+   <tile gid="1913"/>
+   <tile gid="1837"/>
+   <tile gid="2011"/>
+   <tile gid="2013"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1652"/>
+   <tile gid="1693"/>
+   <tile gid="1693"/>
+   <tile gid="1574"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2051"/>
+   <tile gid="2014"/>
+   <tile gid="1975"/>
+   <tile gid="1973"/>
+   <tile gid="1971"/>
+   <tile gid="1972"/>
+   <tile gid="1974"/>
+   <tile gid="2013"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1652"/>
+   <tile gid="1693"/>
+   <tile gid="1693"/>
+   <tile gid="1693"/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2051"/>
+   <tile gid="2014"/>
+   <tile gid="1975"/>
+   <tile gid="1974"/>
+   <tile gid="2012"/>
+   <tile gid="2015"/>
+   <tile gid="2053"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="6318"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2011"/>
+   <tile gid="2012"/>
+   <tile gid="2012"/>
+   <tile gid="2015"/>
+   <tile gid="2053"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="6318"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2011"/>
+   <tile gid="2012"/>
+   <tile gid="2015"/>
+   <tile gid="2053"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2051"/>
+   <tile gid="2014"/>
+   <tile gid="1975"/>
+   <tile gid="1973"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5565"/>
+   <tile gid="5567"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2011"/>
+   <tile gid="2012"/>
+   <tile gid="2013"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="5565"/>
+   <tile gid="5529"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5526"/>
+   <tile gid="5528"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+   <tile gid="5566"/>
+  </data>
+ </layer>
+ <objectgroup id="5" name="Entities">
+  <object id="983" name="Fort" type="BuffTile" gid="6377" x="160" y="480" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="984" name="Tower" type="BuffTile" gid="6327" x="256" y="448" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="985" name="Residence" type="BuffTile" gid="6361" x="320" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="986" name="Fort" type="BuffTile" gid="6378" x="224" y="512" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="987" name="Residence" type="BuffTile" gid="6368" x="256" y="544" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="988" name="Rubble" type="BreakableObstacle" gid="6591" x="320" y="512" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="989" name="Woods" type="BuffTile" gid="1877" x="192" y="448" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="990" name="Drawbridge Switch" type="Switch" gid="6595" x="640" y="576" width="32" height="32">
+   <properties>
+    <property name="triggersId" value="Drawbridge"/>
+   </properties>
+  </object>
+  <object id="991" name="Gate" type="Door" gid="6571" x="96" y="384" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="50"/>
+    <property name="isLocked" type="bool" value="true"/>
+    <property name="isOpen" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="992" name="Push Block" type="Pushable" gid="6635" x="704" y="384" width="32" height="32"/>
+  <object id="994" name="Forge" type="Vendor" gid="6550" x="416" y="512" width="32" height="32">
+   <properties>
+    <property name="items" value="Traveler's Sword|Amateur's Bow|Battle Axe"/>
+    <property name="prices" value="20|30|20"/>
+    <property name="quantities" value="2|2|2"/>
+   </properties>
+  </object>
+  <object id="998" name="Magic Trap" type="Trap" gid="6755" x="320" y="352" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1000" name="Fire Trap" type="Trap" gid="6747" x="928" y="192" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1001" name="Ensnaring Trap" type="Trap" gid="6741" x="640" y="160" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1002" name="Catapult" type="Artillery" gid="6732" x="160" y="320" width="32" height="32">
+   <properties>
+    <property name="range" value="5,6"/>
+   </properties>
+  </object>
+  <object id="1003" name="Ballista" type="Railgun" gid="6733" x="384" y="416" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="20"/>
+   </properties>
+  </object>
+  <object id="1004" name="Drawbridge" type="Drawbridge" gid="6364" x="896" y="416" width="32" height="32">
+   <properties>
+    <property name="canMove" type="bool" value="true"/>
+    <property name="isOpen" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1005" name="Drawbridge" type="Drawbridge" gid="6364" x="928" y="416" width="32" height="32">
+   <properties>
+    <property name="canMove" type="bool" value="true"/>
+    <property name="isOpen" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1008" name="Drawbridge" type="Drawbridge" gid="6364" x="704" y="352" width="32" height="32"/>
+  <object id="1009" name="Drawbridge" type="Drawbridge" gid="6364" x="736" y="352" width="32" height="32"/>
+  <object id="1013" name="Gate" type="Door" gid="6571" x="320" y="320" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="50"/>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1014" name="Gate" type="Door" gid="6571" x="352" y="320" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="50"/>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1016" name="Gate" type="Door" gid="6571" x="128" y="384" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="50"/>
+    <property name="isLocked" type="bool" value="true"/>
+    <property name="isOpen" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1017" name="Ballista" type="Railgun" gid="6733" x="672" y="448" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="20"/>
+   </properties>
+  </object>
+  <object id="1018" name="Catapult" type="Artillery" gid="6732" x="832" y="320" width="32" height="32">
+   <properties>
+    <property name="range" value="5,6"/>
+   </properties>
+  </object>
+  <object id="1019" name="Push Block" type="Pushable" gid="6635" x="352" y="352" width="32" height="32"/>
+  <object id="1020" name="Forge" type="Vendor" gid="6550" x="640" y="512" width="32" height="32">
+   <properties>
+    <property name="items" value="Traveler's Sword|Amateur's Bow|Battle Axe"/>
+    <property name="prices" value="20|30|20"/>
+    <property name="quantities" value="2|2|2"/>
+   </properties>
+  </object>
+  <object id="1021" name="Ensnaring Trap" type="Trap" gid="6741" x="704" y="288" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1022" name="Fire Trap" type="Trap" gid="6747" x="832" y="224" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1023" name="Gate Switch" type="Switch" gid="6595" x="416" y="576" width="32" height="32">
+   <properties>
+    <property name="triggersId" value="Gate"/>
+   </properties>
+  </object>
+  <object id="1024" name="Ballista" type="Railgun" gid="6733" x="672" y="256" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="20"/>
+   </properties>
+  </object>
+  <object id="1025" name="Ballista" type="Railgun" gid="6733" x="352" y="224" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="20"/>
+   </properties>
+  </object>
+  <object id="1026" name="Push Block" type="Pushable" gid="6635" x="288" y="384" width="32" height="32"/>
+  <object id="1027" name="Push Block" type="Pushable" gid="6635" x="768" y="416" width="32" height="32"/>
+  <object id="1031" name="Fort" type="BuffTile" gid="6377" x="672" y="480" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1032" name="Tower" type="BuffTile" gid="6327" x="704" y="544" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1033" name="Residence" type="BuffTile" gid="6361" x="800" y="544" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1034" name="Fort" type="BuffTile" gid="6378" x="864" y="480" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1035" name="Residence" type="BuffTile" gid="6368" x="800" y="480" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1036" name="Rubble" type="BreakableObstacle" gid="6591" x="768" y="512" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1037" name="Woods" type="BuffTile" gid="1877" x="704" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1048" name="Castle" type="BuffTile" gid="6352" x="896" y="96" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+    <property name="blockBonus" type="int" value="2"/>
+    <property name="luckBonus" type="int" value="1"/>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1049" name="Castle" type="BuffTile" gid="6355" x="96" y="96" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+    <property name="blockBonus" type="int" value="2"/>
+    <property name="luckBonus" type="int" value="1"/>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1050" name="Castle Drawbridge" type="Drawbridge" gid="6364" x="896" y="128" width="32" height="32"/>
+  <object id="1051" name="Castle Drawbridge" type="Drawbridge" gid="6364" x="96" y="128" width="32" height="32"/>
+  <object id="1060" name="Locked Door" type="Door" gid="6572" x="800" y="192" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="50"/>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1061" name="Locked Door" type="Door" gid="6572" x="800" y="224" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="50"/>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1062" name="Locked Door" type="Door" gid="6572" x="192" y="192" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="50"/>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1063" name="Locked Door" type="Door" gid="6572" x="192" y="224" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="50"/>
+    <property name="isLocked" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1070" name="Magic Trap" type="Trap" gid="6755" x="736" y="384" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1074" name="Rubble" type="BreakableObstacle" gid="6591" x="256" y="160" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1075" name="Rubble" type="BreakableObstacle" gid="6591" x="736" y="96" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1076" name="Residence" type="BuffTile" gid="6722" x="512" y="128" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1077" name="Residence" type="BuffTile" gid="6722" x="288" y="96" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1078" name="Tower" type="BuffTile" gid="6327" x="352" y="192" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1079" name="Tower" type="BuffTile" gid="6327" x="608" y="160" width="32" height="32">
+   <properties>
+    <property name="atkBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1080" name="Push Block" type="Pushable" gid="6635" x="288" y="128" width="32" height="32"/>
+  <object id="1084" name="Residence" type="BuffTile" gid="6361" x="160" y="544" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1085" name="Residence" type="BuffTile" gid="6361" x="128" y="448" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1086" name="Woods" type="BuffTile" gid="1877" x="128" y="512" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1087" name="Woods" type="BuffTile" gid="1877" x="192" y="544" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1088" name="Woods" type="BuffTile" gid="1877" x="224" y="576" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1089" name="Woods" type="BuffTile" gid="1877" x="288" y="512" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1090" name="Woods" type="BuffTile" gid="1877" x="288" y="416" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1091" name="Woods" type="BuffTile" gid="1877" x="352" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1092" name="Woods" type="BuffTile" gid="1877" x="352" y="544" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1093" name="Woods" type="BuffTile" gid="1877" x="416" y="448" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1094" name="Woods" type="BuffTile" gid="1877" x="448" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1095" name="Woods" type="BuffTile" gid="1877" x="608" y="512" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1096" name="Woods" type="BuffTile" gid="1877" x="640" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1097" name="Woods" type="BuffTile" gid="1877" x="672" y="416" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1098" name="Woods" type="BuffTile" gid="1877" x="768" y="544" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1099" name="Woods" type="BuffTile" gid="1877" x="832" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1100" name="Woods" type="BuffTile" gid="1877" x="864" y="544" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1101" name="Woods" type="BuffTile" gid="1877" x="832" y="416" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1102" name="Residence" type="BuffTile" gid="6361" x="672" y="512" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1103" name="Residence" type="BuffTile" gid="6361" x="736" y="448" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1105" name="Rubble" type="BreakableObstacle" gid="6591" x="352" y="448" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1106" name="Rubble" type="BreakableObstacle" gid="6591" x="672" y="576" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1107" name="Rubble" type="BreakableObstacle" gid="6591" x="384" y="576" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="959" name="Deploy Blue" type="Deployment" gid="6342" x="96" y="320" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="973" name="Deploy Blue" type="Deployment" gid="6342" x="64" y="320" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="974" name="Deploy Blue" type="Deployment" gid="6342" x="928" y="576" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="980" name="Deploy Blue" type="Deployment" gid="6342" x="64" y="288" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="981" name="Deploy Blue" type="Deployment" gid="6342" x="96" y="288" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="982" name="Deploy Blue" type="Deployment" gid="6342" x="128" y="288" width="32" height="32">
+   <properties>
+    <property name="Team" value="Blue"/>
+   </properties>
+  </object>
+  <object id="960" name="Deploy Red" type="Deployment" gid="6350" x="96" y="576" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="975" name="Deploy Red" type="Deployment" gid="6350" x="928" y="352" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="976" name="Deploy Red" type="Deployment" gid="6350" x="896" y="352" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="977" name="Deploy Red" type="Deployment" gid="6350" x="896" y="320" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="978" name="Deploy Red" type="Deployment" gid="6350" x="928" y="320" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="979" name="Deploy Red" type="Deployment" gid="6350" x="864" y="320" width="32" height="32">
+   <properties>
+    <property name="Team" value="Red"/>
+   </properties>
+  </object>
+  <object id="1108" name="Magic Trap" type="Trap" gid="6755" x="96" y="480" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1109" name="Magic Trap" type="Trap" gid="6755" x="896" y="544" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1110" name="Ensnaring Trap" type="Trap" gid="6741" x="256" y="512" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1111" name="Fire Trap" type="Trap" gid="6747" x="864" y="512" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1112" name="Push Block" type="Pushable" gid="6635" x="320" y="96" width="32" height="32"/>
+  <object id="1114" name="Residence" type="BuffTile" gid="6368" x="768" y="192" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1115" name="Residence" type="BuffTile" gid="6375" x="224" y="64" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1116" name="Residence" type="BuffTile" gid="6375" x="544" y="64" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1117" name="Residence" type="BuffTile" gid="6370" x="704" y="64" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1118" name="Rubble" type="BreakableObstacle" gid="6591" x="160" y="288" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1119" name="Ensnaring Trap" type="Trap" gid="6741" x="288" y="448" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1120" name="Ensnaring Trap" type="Trap" gid="6741" x="192" y="512" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1121" name="Ensnaring Trap" type="Trap" gid="6741" x="288" y="576" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1122" name="Ensnaring Trap" type="Trap" gid="6741" x="736" y="576" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1123" name="Ensnaring Trap" type="Trap" gid="6741" x="832" y="544" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1124" name="Ensnaring Trap" type="Trap" gid="6741" x="768" y="448" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1125" name="Ensnaring Trap" type="Trap" gid="6741" x="704" y="512" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1126" name="Residence" type="BuffTile" gid="6368" x="928" y="544" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1127" name="Residence" type="BuffTile" gid="6361" x="896" y="576" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1128" name="Residence" type="BuffTile" gid="6361" x="960" y="512" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1129" name="Fort" type="BuffTile" gid="6378" x="928" y="480" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1130" name="Fort" type="BuffTile" gid="6378" x="96" y="544" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1131" name="Fort" type="BuffTile" gid="6377" x="128" y="576" width="32" height="32">
+   <properties>
+    <property name="blockBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1132" name="Residence" type="BuffTile" gid="6368" x="64" y="448" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1133" name="Woods" type="BuffTile" gid="1877" x="64" y="480" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1134" name="Woods" type="BuffTile" gid="1877" x="32" y="576" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1135" name="Woods" type="BuffTile" gid="1877" x="960" y="576" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1136" name="Woods" type="BuffTile" gid="1877" x="800" y="576" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1137" name="Woods" type="BuffTile" gid="1877" x="960" y="320" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1138" name="Woods" type="BuffTile" gid="1877" x="960" y="384" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1139" name="Woods" type="BuffTile" gid="1877" x="960" y="448" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1142" name="Woods" type="BuffTile" gid="1877" x="384" y="224" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1143" name="Woods" type="BuffTile" gid="1877" x="608" y="224" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1144" name="Woods" type="BuffTile" gid="1877" x="640" y="288" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1145" name="Woods" type="BuffTile" gid="1877" x="256" y="320" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1146" name="Woods" type="BuffTile" gid="1877" x="352" y="160" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1147" name="Woods" type="BuffTile" gid="1877" x="480" y="96" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1148" name="Woods" type="BuffTile" gid="1877" x="576" y="160" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1149" name="Woods" type="BuffTile" gid="1877" x="736" y="64" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1150" name="Woods" type="BuffTile" gid="1877" x="832" y="256" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1151" name="Woods" type="BuffTile" gid="1877" x="960" y="256" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1152" name="Woods" type="BuffTile" gid="1877" x="960" y="224" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1153" name="Woods" type="BuffTile" gid="1877" x="128" y="224" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1154" name="Woods" type="BuffTile" gid="1877" x="32" y="192" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1155" name="Woods" type="BuffTile" gid="1877" x="128" y="160" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1156" name="Woods" type="BuffTile" gid="1877" x="864" y="160" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1157" name="Woods" type="BuffTile" gid="1877" x="928" y="160" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1158" name="Woods" type="BuffTile" gid="1877" x="64" y="160" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1159" name="Woods" type="BuffTile" gid="1877" x="864" y="256" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1160" name="Woods" type="BuffTile" gid="1877" x="928" y="256" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1161" name="Woods" type="BuffTile" gid="1877" x="896" y="256" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1162" name="Woods" type="BuffTile" gid="1877" x="480" y="64" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1163" name="Woods" type="BuffTile" gid="1877" x="384" y="288" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1164" name="Woods" type="BuffTile" gid="1877" x="480" y="576" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1165" name="Woods" type="BuffTile" gid="1877" x="608" y="576" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1166" name="Woods" type="BuffTile" gid="1877" x="320" y="576" width="32" height="32">
+   <properties>
+    <property name="luckBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1167" name="Rubble" type="BreakableObstacle" gid="6591" x="832" y="576" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1168" name="Rubble" type="BreakableObstacle" gid="6591" x="832" y="448" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1169" name="Rubble" type="BreakableObstacle" gid="6591" x="192" y="416" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1170" name="Rubble" type="BreakableObstacle" gid="6591" x="256" y="416" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1171" name="Rubble" type="BreakableObstacle" gid="6591" x="256" y="576" width="32" height="32">
+   <properties>
+    <property name="HP" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="1172" name="Ensnaring Trap" type="Trap" gid="6741" x="160" y="576" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1173" name="Ensnaring Trap" type="Trap" gid="6741" x="928" y="512" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1174" name="Fire Trap" type="Trap" gid="6747" x="288" y="480" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1175" name="Fire Trap" type="Trap" gid="6747" x="64" y="224" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1176" name="Fire Trap" type="Trap" gid="6747" x="128" y="192" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="false"/>
+   </properties>
+  </object>
+  <object id="1177" name="Catapult" type="Artillery" gid="6732" x="832" y="512" width="32" height="32">
+   <properties>
+    <property name="range" value="5,6"/>
+   </properties>
+  </object>
+  <object id="1178" name="Catapult" type="Artillery" gid="6732" x="160" y="512" width="32" height="32">
+   <properties>
+    <property name="range" value="5,6"/>
+   </properties>
+  </object>
+  <object id="1179" name="Ensnaring Trap" type="Trap" gid="6741" x="320" y="256" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1180" name="Ensnaring Trap" type="Trap" gid="6741" x="256" y="96" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="3"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+    <property name="willSnare" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1181" name="Castle Bridge Plate" type="PressurePlate" gid="6670" x="896" y="160" width="32" height="32">
+   <properties>
+    <property name="triggersId" value="Castle Drawbridge"/>
+   </properties>
+  </object>
+  <object id="1182" name="Castle Bridge Plate" type="PressurePlate" gid="6670" x="96" y="160" width="32" height="32">
+   <properties>
+    <property name="triggersId" value="Castle Drawbridge"/>
+   </properties>
+  </object>
+  <object id="1183" name="Regal Chest" type="Chest" gid="6686" x="288" y="256" width="32" height="32">
+   <properties>
+    <property name="item" value="Health Potion"/>
+   </properties>
+  </object>
+  <object id="1184" name="Regal Chest" type="Chest" gid="6694" x="736" y="288" width="32" height="32">
+   <properties>
+    <property name="item" value="Health Potion"/>
+   </properties>
+  </object>
+  <object id="1186" name="Ballista" type="Railgun" gid="6733" x="224" y="448" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="20"/>
+   </properties>
+  </object>
+  <object id="1187" name="Ballista" type="Railgun" gid="6733" x="736" y="512" width="32" height="32">
+   <properties>
+    <property name="range" type="int" value="20"/>
+   </properties>
+  </object>
+  <object id="1082" name="Push Block" type="Pushable" gid="6635" x="704" y="192" width="32" height="32"/>
+  <object id="1083" name="Push Block" type="Pushable" gid="6635" x="640" y="96" width="32" height="32"/>
+  <object id="1104" name="Residence" type="BuffTile" gid="6368" x="224" y="416" width="32" height="32">
+   <properties>
+    <property name="retBonus" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1140" name="Magic Trap" type="Trap" gid="6755" x="352" y="512" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1141" name="Magic Trap" type="Trap" gid="6755" x="672" y="544" width="32" height="32">
+   <properties>
+    <property name="damage" type="int" value="5"/>
+    <property name="limitedTriggers" type="bool" value="true"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="6" name="Loot" opacity="0.75">
+  <object id="995" name="Battle Axe" type="Weapon" gid="6803" x="704" y="32" width="32" height="32">
+   <properties>
+    <property name="atkRange" value="1"/>
+    <property name="atkValue" type="int" value="7"/>
+    <property name="luckModifier" type="int" value="-5"/>
+   </properties>
+  </object>
+  <object id="996" name="Traveler's Sword" type="Weapon" gid="6823" x="736" y="32" width="32" height="32">
+   <properties>
+    <property name="atkValue" type="int" value="6"/>
+    <property name="luckModifier" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="997" name="Amateur's Bow" type="Weapon" gid="6824" x="768" y="32" width="32" height="32">
+   <properties>
+    <property name="atkRange" value="2,3"/>
+    <property name="atkValue" type="int" value="5"/>
+    <property name="luckModifier" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="1067" name="Door Key" type="Key" gid="6399" x="832" y="32" width="32" height="32">
+   <properties>
+    <property name="usedWith" value="Locked Door"/>
+   </properties>
+  </object>
+  <object id="1069" name="Usurper's Crown" type="Relic" gid="6463" x="896" y="32" width="32" height="32"/>
+  <object id="1185" name="Health Potion" type="HealthPotion" gid="6487" x="640" y="32" width="32" height="32">
+   <properties>
+    <property name="hpHealed" type="int" value="5"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="11" name="Summons" opacity="0.69">
+  <object id="961" name="Slime" type="Creep" gid="21" x="32" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="971" name="Skeleton" type="Creep" gid="26" x="0" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="7" name="Items"/>
+ <objectgroup id="8" name="Units">
+  <object id="1028" name="Skeleton" type="Creep" gid="26" x="320" y="448" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1029" name="Skeleton" type="Creep" gid="26" x="736" y="480" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1038" name="Skeleton" type="Creep" gid="26" x="800" y="448" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1039" name="Skeleton" type="Creep" gid="26" x="736" y="544" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1040" name="Skeleton" type="Creep" gid="26" x="800" y="512" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1041" name="Skeleton" type="Creep" gid="26" x="192" y="480" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1042" name="Skeleton" type="Creep" gid="26" x="256" y="480" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1043" name="Skeleton" type="Creep" gid="26" x="320" y="544" width="32" height="32">
+   <properties>
+    <property name="Class" value="Skeleton"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1044" name="Rat" type="Creep" gid="29" x="256" y="256" width="32" height="32">
+   <properties>
+    <property name="Class" value="Rat"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_basicAttack" type="bool" value="false"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1045" name="Rat" type="Creep" gid="29" x="672" y="192" width="32" height="32">
+   <properties>
+    <property name="Class" value="Rat"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_basicAttack" type="bool" value="false"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1046" name="Necromancer" type="Creep" gid="25" x="96" y="96" width="32" height="32">
+   <properties>
+    <property name="Class" value="Necromancer"/>
+    <property name="Commander" type="bool" value="true"/>
+    <property name="Items" value="Usurper's Crown"/>
+    <property name="fallback_routine" value="routine_wait"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Skeleton"/>
+   </properties>
+  </object>
+  <object id="1047" name="Necromancer" type="Creep" gid="25" x="896" y="96" width="32" height="32">
+   <properties>
+    <property name="Class" value="Necromancer"/>
+    <property name="Commander" type="bool" value="true"/>
+    <property name="Items" value="Usurper's Crown"/>
+    <property name="fallback_routine" value="routine_wait"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Skeleton"/>
+   </properties>
+  </object>
+  <object id="1066" name="Troll" type="Creep" gid="22" x="576" y="96" width="32" height="32">
+   <properties>
+    <property name="Class" value="Troll"/>
+    <property name="Independent" type="bool" value="true"/>
+    <property name="Items" value="Door Key"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1068" name="Troll" type="Creep" gid="22" x="320" y="160" width="32" height="32">
+   <properties>
+    <property name="Class" value="Troll"/>
+    <property name="Independent" type="bool" value="true"/>
+    <property name="Items" value="Door Key"/>
+    <property name="gold" type="int" value="5"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1071" name="Orc" type="Creep" gid="23" x="96" y="512" width="32" height="32">
+   <properties>
+    <property name="Class" value="Orc"/>
+    <property name="gold" type="int" value="10"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="1072" name="Orc" type="Creep" gid="23" x="896" y="512" width="32" height="32">
+   <properties>
+    <property name="Class" value="Orc"/>
+    <property name="gold" type="int" value="10"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="9" name="Disabled" opacity="0.24">
+  <object id="963" name="Slime" type="Creep" gid="21" x="448" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Slime"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Slime"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="965" name="Orc" type="Creep" gid="23" x="256" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Orc"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="966" name="Rat" type="Creep" gid="29" x="288" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Rat"/>
+    <property name="routine_basicAttack" type="bool" value="false"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_treasureHunter" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="967" name="Bat" type="Creep" gid="30" x="352" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Bat"/>
+    <property name="routine_prey" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="968" name="Spider" type="Creep" gid="28" x="384" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Spider"/>
+    <property name="routine_defender" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="969" name="Goblin" type="Creep" gid="27" x="416" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Goblin"/>
+    <property name="routine_basicAttack" type="bool" value="false"/>
+    <property name="routine_glutton" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_triggerHappy" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="970" name="Troll" type="Creep" gid="22" x="224" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Troll"/>
+    <property name="Independent" type="bool" value="true"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="972" name="Necromancer" type="Creep" gid="25" x="320" y="32" width="32" height="32">
+   <properties>
+    <property name="Class" value="Necromancer"/>
+    <property name="Commander" type="bool" value="true"/>
+    <property name="fallback_routine" value="routine_wait"/>
+    <property name="routine_defender" type="bool" value="true"/>
+    <property name="routine_kingslayer" type="bool" value="true"/>
+    <property name="routine_prey" type="bool" value="true"/>
+    <property name="routine_summon" type="bool" value="true"/>
+    <property name="routine_summon.class" value="Skeleton"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <layer id="4" name="Overlay" width="32" height="20">
+  <data>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="387"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="2015"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1975"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="1975"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="387"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile gid="427"/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+   <tile/>
+  </data>
+ </layer>
+</map>

--- a/SolStandard/Content/TmxMaps/Map_Select_04.tmx
+++ b/SolStandard/Content/TmxMaps/Map_Select_04.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="30" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="10" nextobjectid="577">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="30" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="10" nextobjectid="578">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -2065,6 +2065,19 @@
     <property name="modeAssassinate" type="bool" value="false"/>
     <property name="modeRelic.goal" type="int" value="4"/>
     <property name="modeRelic.vs" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="577" name="Factory Heist" type="SelectMap" gid="6316" x="384" y="416" width="32" height="32">
+   <properties>
+    <property name="draftUnits" type="bool" value="true"/>
+    <property name="mapFileName" value="Draft_Factory_Floor.tmx"/>
+    <property name="mapSong" value="DesertTheme"/>
+    <property name="maxUnitsBlue" type="int" value="6"/>
+    <property name="maxUnitsRed" type="int" value="6"/>
+    <property name="modeAssassinate" type="bool" value="false"/>
+    <property name="modeEscape" type="bool" value="true"/>
+    <property name="modeEscape.team" value="Blue"/>
+    <property name="modeRoutArmy" type="bool" value="true"/>
    </properties>
   </object>
  </objectgroup>

--- a/SolStandard/Content/TmxMaps/Map_Select_04.tmx
+++ b/SolStandard/Content/TmxMaps/Map_Select_04.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="30" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="10" nextobjectid="578">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="30" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="10" nextobjectid="579">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -2078,6 +2078,16 @@
     <property name="modeEscape" type="bool" value="true"/>
     <property name="modeEscape.team" value="Blue"/>
     <property name="modeRoutArmy" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="578" name="Arctic Quest VS" type="SelectMap" gid="6320" x="352" y="64" width="32" height="32">
+   <properties>
+    <property name="mapFileName" value="Draft_Quest_Race.tmx"/>
+    <property name="maxUnitsBlue" type="int" value="6"/>
+    <property name="maxUnitsRed" type="int" value="6"/>
+    <property name="modeAssassinate" type="bool" value="false"/>
+    <property name="modeRelic.goal" type="int" value="1"/>
+    <property name="modeRelic.vs" type="bool" value="true"/>
    </properties>
   </object>
  </objectgroup>

--- a/SolStandard/Content/TmxMaps/Map_Select_04.tmx
+++ b/SolStandard/Content/TmxMaps/Map_Select_04.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="30" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="10" nextobjectid="575">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="30" height="20" tilewidth="32" tileheight="32" infinite="0" nextlayerid="10" nextobjectid="577">
  <tileset firstgid="1" name="units-32" tilewidth="32" tileheight="32" tilecount="30" columns="10">
   <image source="../Graphics/Map/Tiles/Units3.png" width="320" height="96"/>
  </tileset>
@@ -2054,7 +2054,17 @@
     <property name="maxUnitsRed" type="int" value="6"/>
     <property name="modeAssassinate" type="bool" value="false"/>
     <property name="modeRelic.coop" type="bool" value="true"/>
-    <property name="modeRelic.goal" type="int" value="2"/>
+    <property name="modeRelic.goal" type="int" value="3"/>
+   </properties>
+  </object>
+  <object id="576" name="Hiatok Fortress VS" type="SelectMap" gid="6320" x="320" y="384" width="32" height="32">
+   <properties>
+    <property name="mapFileName" value="Draft_Hiatok_Fortress.tmx"/>
+    <property name="maxUnitsBlue" type="int" value="6"/>
+    <property name="maxUnitsRed" type="int" value="6"/>
+    <property name="modeAssassinate" type="bool" value="false"/>
+    <property name="modeRelic.goal" type="int" value="4"/>
+    <property name="modeRelic.vs" type="bool" value="true"/>
    </properties>
   </object>
  </objectgroup>

--- a/SolStandard/Content/TmxMaps/entities-32.tsx
+++ b/SolStandard/Content/TmxMaps/entities-32.tsx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tileset version="1.2" tiledversion="1.2.4" name="entities-32" tilewidth="32" tileheight="32" tilecount="552" columns="8">
- <image source="../Graphics/Map/Tiles/entities-32.png" width="256" height="2208"/>
+<tileset version="1.2" tiledversion="1.2.4" name="entities-32" tilewidth="32" tileheight="32" tilecount="584" columns="8">
+ <image source="../Graphics/Map/Tiles/entities-32.png" width="256" height="2336"/>
  <tile id="0">
   <animation>
    <frame tileid="528" duration="200"/>
@@ -401,6 +401,46 @@
    <frame tileid="445" duration="200"/>
    <frame tileid="446" duration="200"/>
    <frame tileid="447" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="552">
+  <animation>
+   <frame tileid="552" duration="200"/>
+   <frame tileid="560" duration="200"/>
+   <frame tileid="568" duration="200"/>
+   <frame tileid="576" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="553">
+  <animation>
+   <frame tileid="553" duration="200"/>
+   <frame tileid="561" duration="200"/>
+   <frame tileid="569" duration="200"/>
+   <frame tileid="577" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="554">
+  <animation>
+   <frame tileid="554" duration="200"/>
+   <frame tileid="562" duration="200"/>
+   <frame tileid="570" duration="200"/>
+   <frame tileid="578" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="555">
+  <animation>
+   <frame tileid="555" duration="200"/>
+   <frame tileid="563" duration="200"/>
+   <frame tileid="571" duration="200"/>
+   <frame tileid="579" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="556">
+  <animation>
+   <frame tileid="556" duration="200"/>
+   <frame tileid="564" duration="200"/>
+   <frame tileid="572" duration="200"/>
+   <frame tileid="580" duration="200"/>
   </animation>
  </tile>
 </tileset>

--- a/SolStandard/Content/TmxMaps/objecttypes.xml
+++ b/SolStandard/Content/TmxMaps/objecttypes.xml
@@ -130,6 +130,9 @@
  <objecttype name="Movable" color="#0000ff">
   <property name="canMove" type="bool" default="true"/>
  </objecttype>
+ <objecttype name="Piston" color="#815e33">
+  <property name="direction" type="string" default="NORTH|SOUTH|EAST|WEST"/>
+ </objecttype>
  <objecttype name="Player" color="#0000ff"/>
  <objecttype name="Portal" color="#aaaaff">
   <property name="canMove" type="bool" default="true"/>

--- a/SolStandard/Content/TmxMaps/objecttypes.xml
+++ b/SolStandard/Content/TmxMaps/objecttypes.xml
@@ -80,6 +80,9 @@
   <property name="routine_wait" type="bool" default="false"/>
   <property name="routine_wander" type="bool" default="false"/>
  </objecttype>
+ <objecttype name="Crossing" color="#aa0000">
+  <property name="direction" type="string" default="NONE|UP|DOWN|LEFT|RIGHT"/>
+ </objecttype>
  <objecttype name="Currency" color="#dad45e">
   <property name="canMove" type="bool" default="true"/>
   <property name="itemPool" type="string"/>

--- a/SolStandard/Content/TmxMaps/objecttypes.xml
+++ b/SolStandard/Content/TmxMaps/objecttypes.xml
@@ -72,6 +72,7 @@
   <property name="Items" type="string"/>
   <property name="Team" type="string" default="Creep"/>
   <property name="fallback_routine" type="string" default="routine_wander"/>
+  <property name="gold" type="int" default="0"/>
   <property name="routine_basicAttack" type="bool" default="true"/>
   <property name="routine_defender" type="bool" default="false"/>
   <property name="routine_glutton" type="bool" default="false"/>

--- a/SolStandard/Content/TmxMaps/objecttypes.xml
+++ b/SolStandard/Content/TmxMaps/objecttypes.xml
@@ -121,6 +121,9 @@
   <property name="canMove" type="bool" default="true"/>
   <property name="itemPool" type="string"/>
  </objecttype>
+ <objecttype name="Launchpad" color="#3aa413">
+  <property name="radius" type="string" default="2,3"/>
+ </objecttype>
  <objecttype name="Magnet" color="#1685a4">
   <property name="itemPool" type="string"/>
   <property name="pickupRange" type="string" default="0"/>
@@ -187,6 +190,13 @@
   <property name="modeSoloDefeatBoss" type="bool" default="false"/>
   <property name="modeTaxes" type="bool" default="false"/>
   <property name="valueTaxes" type="int" default="100"/>
+ </objecttype>
+ <objecttype name="SpringTrap" color="#dbde1d">
+  <property name="trigger.endOfTurn" type="bool" default="true"/>
+  <property name="trigger.landingCoordinates.x" type="int" default="0"/>
+  <property name="trigger.landingCoordinates.y" type="int" default="0"/>
+  <property name="trigger.remotely" type="bool" default="false"/>
+  <property name="trigger.startOfTurn" type="bool" default="false"/>
  </objecttype>
  <objecttype name="Switch" color="#ff7029">
   <property name="canMove" type="bool" default="false"/>

--- a/SolStandard/Content/TmxMaps/objecttypes.xml
+++ b/SolStandard/Content/TmxMaps/objecttypes.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <objecttypes>
+ <objecttype name="ArrowTrap" color="#a0a0a4">
+  <property name="damage" type="int" default="3"/>
+  <property name="direction" type="string" default="WEST|EAST|SOUTH|NORTH"/>
+ </objecttype>
  <objecttype name="Artillery" color="#f42ad9">
   <property name="canMove" type="bool" default="true"/>
   <property name="damage" type="int" default="5"/>

--- a/SolStandard/Content/TmxMaps/overworld-32.tsx
+++ b/SolStandard/Content/TmxMaps/overworld-32.tsx
@@ -90,8 +90,6 @@
  <tile id="42" terrain="0,0,1,0"/>
  <tile id="43" terrain="0,1,1,1"/>
  <tile id="44" terrain="1,0,1,1"/>
- <tile id="45" terrain="1,1,1,1"/>
- <tile id="46" terrain="1,1,1,1"/>
  <tile id="60">
   <animation>
    <frame tileid="72" duration="100"/>
@@ -136,8 +134,6 @@
  <tile id="82" terrain="1,0,1,0"/>
  <tile id="83" terrain="1,1,0,1"/>
  <tile id="84" terrain="1,1,1,0"/>
- <tile id="85" terrain="1,1,1,1"/>
- <tile id="86" terrain="1,1,1,1"/>
  <tile id="100">
   <animation>
    <frame tileid="112" duration="100"/>

--- a/SolStandard/Content/TmxMaps/overworld-32.tsx
+++ b/SolStandard/Content/TmxMaps/overworld-32.tsx
@@ -1840,6 +1840,246 @@
  <tile id="3333" terrain=",35,,"/>
  <tile id="3334" terrain=",,35,35"/>
  <tile id="3335" terrain="35,,,"/>
+ <tile id="3480">
+  <animation>
+   <frame tileid="3480" duration="200"/>
+   <frame tileid="3480" duration="200"/>
+   <frame tileid="3483" duration="200"/>
+   <frame tileid="3483" duration="200"/>
+   <frame tileid="3486" duration="200"/>
+   <frame tileid="3486" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3481">
+  <animation>
+   <frame tileid="3481" duration="200"/>
+   <frame tileid="3481" duration="200"/>
+   <frame tileid="3484" duration="200"/>
+   <frame tileid="3484" duration="200"/>
+   <frame tileid="3487" duration="200"/>
+   <frame tileid="3487" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3482">
+  <animation>
+   <frame tileid="3482" duration="200"/>
+   <frame tileid="3482" duration="200"/>
+   <frame tileid="3485" duration="200"/>
+   <frame tileid="3485" duration="200"/>
+   <frame tileid="3488" duration="200"/>
+   <frame tileid="3488" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3520">
+  <animation>
+   <frame tileid="3520" duration="200"/>
+   <frame tileid="3520" duration="200"/>
+   <frame tileid="3523" duration="200"/>
+   <frame tileid="3523" duration="200"/>
+   <frame tileid="3526" duration="200"/>
+   <frame tileid="3526" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3521">
+  <animation>
+   <frame tileid="3521" duration="200"/>
+   <frame tileid="3521" duration="200"/>
+   <frame tileid="3524" duration="200"/>
+   <frame tileid="3524" duration="200"/>
+   <frame tileid="3527" duration="200"/>
+   <frame tileid="3527" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3522">
+  <animation>
+   <frame tileid="3522" duration="200"/>
+   <frame tileid="3522" duration="200"/>
+   <frame tileid="3525" duration="200"/>
+   <frame tileid="3525" duration="200"/>
+   <frame tileid="3528" duration="200"/>
+   <frame tileid="3528" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3560">
+  <animation>
+   <frame tileid="3560" duration="200"/>
+   <frame tileid="3560" duration="200"/>
+   <frame tileid="3563" duration="200"/>
+   <frame tileid="3563" duration="200"/>
+   <frame tileid="3566" duration="200"/>
+   <frame tileid="3566" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3561">
+  <animation>
+   <frame tileid="3561" duration="200"/>
+   <frame tileid="3561" duration="200"/>
+   <frame tileid="3564" duration="200"/>
+   <frame tileid="3564" duration="200"/>
+   <frame tileid="3567" duration="200"/>
+   <frame tileid="3567" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3562">
+  <animation>
+   <frame tileid="3562" duration="200"/>
+   <frame tileid="3562" duration="200"/>
+   <frame tileid="3565" duration="200"/>
+   <frame tileid="3565" duration="200"/>
+   <frame tileid="3568" duration="200"/>
+   <frame tileid="3568" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3600">
+  <animation>
+   <frame tileid="3600" duration="200"/>
+   <frame tileid="3600" duration="200"/>
+   <frame tileid="3603" duration="200"/>
+   <frame tileid="3603" duration="200"/>
+   <frame tileid="3606" duration="200"/>
+   <frame tileid="3606" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3601">
+  <animation>
+   <frame tileid="3601" duration="200"/>
+   <frame tileid="3601" duration="200"/>
+   <frame tileid="3604" duration="200"/>
+   <frame tileid="3604" duration="200"/>
+   <frame tileid="3607" duration="200"/>
+   <frame tileid="3607" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3602">
+  <animation>
+   <frame tileid="3602" duration="200"/>
+   <frame tileid="3602" duration="200"/>
+   <frame tileid="3605" duration="200"/>
+   <frame tileid="3605" duration="200"/>
+   <frame tileid="3608" duration="200"/>
+   <frame tileid="3608" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3640">
+  <animation>
+   <frame tileid="3640" duration="200"/>
+   <frame tileid="3640" duration="200"/>
+   <frame tileid="3643" duration="200"/>
+   <frame tileid="3643" duration="200"/>
+   <frame tileid="3646" duration="200"/>
+   <frame tileid="3646" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3641">
+  <animation>
+   <frame tileid="3641" duration="200"/>
+   <frame tileid="3641" duration="200"/>
+   <frame tileid="3644" duration="200"/>
+   <frame tileid="3644" duration="200"/>
+   <frame tileid="3647" duration="200"/>
+   <frame tileid="3647" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3642">
+  <animation>
+   <frame tileid="3642" duration="200"/>
+   <frame tileid="3642" duration="200"/>
+   <frame tileid="3645" duration="200"/>
+   <frame tileid="3645" duration="200"/>
+   <frame tileid="3648" duration="200"/>
+   <frame tileid="3648" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3680">
+  <animation>
+   <frame tileid="3680" duration="200"/>
+   <frame tileid="3680" duration="200"/>
+   <frame tileid="3683" duration="200"/>
+   <frame tileid="3683" duration="200"/>
+   <frame tileid="3686" duration="200"/>
+   <frame tileid="3686" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3681">
+  <animation>
+   <frame tileid="3681" duration="200"/>
+   <frame tileid="3681" duration="200"/>
+   <frame tileid="3684" duration="200"/>
+   <frame tileid="3684" duration="200"/>
+   <frame tileid="3687" duration="200"/>
+   <frame tileid="3687" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3682">
+  <animation>
+   <frame tileid="3682" duration="200"/>
+   <frame tileid="3682" duration="200"/>
+   <frame tileid="3685" duration="200"/>
+   <frame tileid="3685" duration="200"/>
+   <frame tileid="3688" duration="200"/>
+   <frame tileid="3688" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3720">
+  <animation>
+   <frame tileid="3720" duration="200"/>
+   <frame tileid="3720" duration="200"/>
+   <frame tileid="3723" duration="200"/>
+   <frame tileid="3723" duration="200"/>
+   <frame tileid="3726" duration="200"/>
+   <frame tileid="3726" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3721">
+  <animation>
+   <frame tileid="3721" duration="200"/>
+   <frame tileid="3721" duration="200"/>
+   <frame tileid="3724" duration="200"/>
+   <frame tileid="3724" duration="200"/>
+   <frame tileid="3727" duration="200"/>
+   <frame tileid="3727" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3722">
+  <animation>
+   <frame tileid="3722" duration="200"/>
+   <frame tileid="3722" duration="200"/>
+   <frame tileid="3725" duration="200"/>
+   <frame tileid="3725" duration="200"/>
+   <frame tileid="3728" duration="200"/>
+   <frame tileid="3728" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3760">
+  <animation>
+   <frame tileid="3760" duration="200"/>
+   <frame tileid="3760" duration="200"/>
+   <frame tileid="3763" duration="200"/>
+   <frame tileid="3763" duration="200"/>
+   <frame tileid="3766" duration="200"/>
+   <frame tileid="3766" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3761">
+  <animation>
+   <frame tileid="3761" duration="200"/>
+   <frame tileid="3761" duration="200"/>
+   <frame tileid="3764" duration="200"/>
+   <frame tileid="3764" duration="200"/>
+   <frame tileid="3767" duration="200"/>
+   <frame tileid="3767" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="3762">
+  <animation>
+   <frame tileid="3762" duration="200"/>
+   <frame tileid="3762" duration="200"/>
+   <frame tileid="3765" duration="200"/>
+   <frame tileid="3765" duration="200"/>
+   <frame tileid="3768" duration="200"/>
+   <frame tileid="3768" duration="200"/>
+  </animation>
+ </tile>
  <tile id="4040" terrain="22,22,22,21"/>
  <tile id="4041" terrain="22,22,21,21"/>
  <tile id="4042" terrain="22,22,21,22"/>

--- a/SolStandard/Content/TmxMaps/overworld-32.tsx
+++ b/SolStandard/Content/TmxMaps/overworld-32.tsx
@@ -1254,12 +1254,76 @@
    <frame tileid="1679" duration="100"/>
   </animation>
  </tile>
+ <tile id="1700">
+  <animation>
+   <frame tileid="1700" duration="200"/>
+   <frame tileid="1704" duration="200"/>
+   <frame tileid="1708" duration="200"/>
+   <frame tileid="1712" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1701">
+  <animation>
+   <frame tileid="1701" duration="200"/>
+   <frame tileid="1705" duration="200"/>
+   <frame tileid="1709" duration="200"/>
+   <frame tileid="1713" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1702">
+  <animation>
+   <frame tileid="1702" duration="200"/>
+   <frame tileid="1706" duration="200"/>
+   <frame tileid="1710" duration="200"/>
+   <frame tileid="1714" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1703">
+  <animation>
+   <frame tileid="1703" duration="200"/>
+   <frame tileid="1707" duration="200"/>
+   <frame tileid="1711" duration="200"/>
+   <frame tileid="1715" duration="200"/>
+  </animation>
+ </tile>
  <tile id="1716">
   <animation>
    <frame tileid="1716" duration="100"/>
    <frame tileid="1717" duration="100"/>
    <frame tileid="1718" duration="100"/>
    <frame tileid="1719" duration="100"/>
+  </animation>
+ </tile>
+ <tile id="1740">
+  <animation>
+   <frame tileid="1740" duration="200"/>
+   <frame tileid="1744" duration="200"/>
+   <frame tileid="1748" duration="200"/>
+   <frame tileid="1752" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1741">
+  <animation>
+   <frame tileid="1741" duration="200"/>
+   <frame tileid="1745" duration="200"/>
+   <frame tileid="1749" duration="200"/>
+   <frame tileid="1753" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1742">
+  <animation>
+   <frame tileid="1742" duration="200"/>
+   <frame tileid="1746" duration="200"/>
+   <frame tileid="1750" duration="200"/>
+   <frame tileid="1754" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1743">
+  <animation>
+   <frame tileid="1743" duration="200"/>
+   <frame tileid="1747" duration="200"/>
+   <frame tileid="1751" duration="200"/>
+   <frame tileid="1755" duration="200"/>
   </animation>
  </tile>
  <tile id="1756">
@@ -1270,12 +1334,68 @@
    <frame tileid="1759" duration="100"/>
   </animation>
  </tile>
+ <tile id="1780">
+  <animation>
+   <frame tileid="1780" duration="200"/>
+   <frame tileid="1784" duration="200"/>
+   <frame tileid="1788" duration="200"/>
+   <frame tileid="1792" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1781">
+  <animation>
+   <frame tileid="1781" duration="200"/>
+   <frame tileid="1785" duration="200"/>
+   <frame tileid="1789" duration="200"/>
+   <frame tileid="1793" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1782">
+  <animation>
+   <frame tileid="1782" duration="200"/>
+   <frame tileid="1786" duration="200"/>
+   <frame tileid="1790" duration="200"/>
+   <frame tileid="1794" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1783">
+  <animation>
+   <frame tileid="1783" duration="200"/>
+   <frame tileid="1787" duration="200"/>
+   <frame tileid="1791" duration="200"/>
+   <frame tileid="1795" duration="200"/>
+  </animation>
+ </tile>
  <tile id="1800" terrain=",,,36"/>
  <tile id="1801" terrain=",,36,36"/>
  <tile id="1802" terrain=",,36,"/>
  <tile id="1803" terrain=",36,36,36"/>
  <tile id="1804" terrain="36,,36,36"/>
  <tile id="1805" terrain="36,36,36,36"/>
+ <tile id="1820">
+  <animation>
+   <frame tileid="1820" duration="200"/>
+   <frame tileid="1824" duration="200"/>
+   <frame tileid="1828" duration="200"/>
+   <frame tileid="1832" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1821">
+  <animation>
+   <frame tileid="1821" duration="200"/>
+   <frame tileid="1825" duration="200"/>
+   <frame tileid="1829" duration="200"/>
+   <frame tileid="1833" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1823">
+  <animation>
+   <frame tileid="1823" duration="200"/>
+   <frame tileid="1827" duration="200"/>
+   <frame tileid="1831" duration="200"/>
+   <frame tileid="1835" duration="200"/>
+  </animation>
+ </tile>
  <tile id="1840" terrain=",36,,36"/>
  <tile id="1841" terrain="36,36,36,36"/>
  <tile id="1842" terrain="36,,36,"/>
@@ -1287,21 +1407,119 @@
  <tile id="1882" terrain="36,,,"/>
  <tile id="1883" terrain=",36,36,"/>
  <tile id="1884" terrain="36,,,36"/>
- <tile id="1940" terrain=",,,39"/>
- <tile id="1941" terrain=",,39,39"/>
- <tile id="1942" terrain=",,39,"/>
- <tile id="1943" terrain=",39,39,39"/>
- <tile id="1944" terrain="39,,39,39"/>
- <tile id="1980" terrain=",39,,39"/>
+ <tile id="1940" terrain=",,,39">
+  <animation>
+   <frame tileid="1940" duration="200"/>
+   <frame tileid="1945" duration="200"/>
+   <frame tileid="1950" duration="200"/>
+   <frame tileid="1955" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1941" terrain=",,39,39">
+  <animation>
+   <frame tileid="1941" duration="200"/>
+   <frame tileid="1946" duration="200"/>
+   <frame tileid="1951" duration="200"/>
+   <frame tileid="1956" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1942" terrain=",,39,">
+  <animation>
+   <frame tileid="1942" duration="200"/>
+   <frame tileid="1947" duration="200"/>
+   <frame tileid="1952" duration="200"/>
+   <frame tileid="1957" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1943" terrain=",39,39,39">
+  <animation>
+   <frame tileid="1943" duration="200"/>
+   <frame tileid="1948" duration="200"/>
+   <frame tileid="1953" duration="200"/>
+   <frame tileid="1958" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1944" terrain="39,,39,39">
+  <animation>
+   <frame tileid="1944" duration="200"/>
+   <frame tileid="1949" duration="200"/>
+   <frame tileid="1954" duration="200"/>
+   <frame tileid="1959" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1980" terrain=",39,,39">
+  <animation>
+   <frame tileid="1980" duration="200"/>
+   <frame tileid="1985" duration="200"/>
+   <frame tileid="1990" duration="200"/>
+   <frame tileid="1995" duration="200"/>
+  </animation>
+ </tile>
  <tile id="1981" terrain="39,39,39,39"/>
- <tile id="1982" terrain="39,,39,"/>
- <tile id="1983" terrain="39,39,,39"/>
- <tile id="1984" terrain="39,39,39,"/>
- <tile id="2020" terrain=",39,,"/>
- <tile id="2021" terrain="39,39,,"/>
- <tile id="2022" terrain="39,,,"/>
- <tile id="2023" terrain=",39,39,"/>
- <tile id="2024" terrain="39,,,39"/>
+ <tile id="1982" terrain="39,,39,">
+  <animation>
+   <frame tileid="1982" duration="200"/>
+   <frame tileid="1987" duration="200"/>
+   <frame tileid="1992" duration="200"/>
+   <frame tileid="1997" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1983" terrain="39,39,,39">
+  <animation>
+   <frame tileid="1983" duration="200"/>
+   <frame tileid="1988" duration="200"/>
+   <frame tileid="1993" duration="200"/>
+   <frame tileid="1998" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="1984" terrain="39,39,39,">
+  <animation>
+   <frame tileid="1984" duration="200"/>
+   <frame tileid="1989" duration="200"/>
+   <frame tileid="1994" duration="200"/>
+   <frame tileid="1999" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="2020" terrain=",39,,">
+  <animation>
+   <frame tileid="2020" duration="200"/>
+   <frame tileid="2025" duration="200"/>
+   <frame tileid="2030" duration="200"/>
+   <frame tileid="2035" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="2021" terrain="39,39,,">
+  <animation>
+   <frame tileid="2021" duration="200"/>
+   <frame tileid="2026" duration="200"/>
+   <frame tileid="2031" duration="200"/>
+   <frame tileid="2036" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="2022" terrain="39,,,">
+  <animation>
+   <frame tileid="2022" duration="200"/>
+   <frame tileid="2027" duration="200"/>
+   <frame tileid="2032" duration="200"/>
+   <frame tileid="2037" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="2023" terrain=",39,39,">
+  <animation>
+   <frame tileid="2023" duration="200"/>
+   <frame tileid="2028" duration="200"/>
+   <frame tileid="2033" duration="200"/>
+   <frame tileid="2038" duration="200"/>
+  </animation>
+ </tile>
+ <tile id="2024" terrain="39,,,39">
+  <animation>
+   <frame tileid="2024" duration="200"/>
+   <frame tileid="2029" duration="200"/>
+   <frame tileid="2034" duration="200"/>
+   <frame tileid="2039" duration="200"/>
+  </animation>
+ </tile>
  <tile id="2040" terrain=",,,37"/>
  <tile id="2041" terrain=",,37,37"/>
  <tile id="2042" terrain=",,37,"/>

--- a/SolStandard/Entity/General/Chest.cs
+++ b/SolStandard/Entity/General/Chest.cs
@@ -8,6 +8,7 @@ using SolStandard.Entity.General.Item;
 using SolStandard.Entity.Unit;
 using SolStandard.Entity.Unit.Actions;
 using SolStandard.Entity.Unit.Actions.Terrain;
+using SolStandard.HUD.Window;
 using SolStandard.HUD.Window.Content;
 using SolStandard.Utility;
 using SolStandard.Utility.Assets;
@@ -18,6 +19,18 @@ namespace SolStandard.Entity.General
 {
     public class Chest : TerrainEntity, IActionTile, IOpenable, ILockable, ITriggerable
     {
+        private enum LockIconState
+        {
+            Locked,
+            Unlocked
+        }
+
+        private enum OpenCloseIconState
+        {
+            Closed,
+            Open
+        }
+
         public int Gold { get; }
         public bool IsLocked { get; private set; }
         public bool IsOpen { get; private set; }
@@ -48,7 +61,6 @@ namespace SolStandard.Entity.General
                 List<string> itemList = new List<string>();
                 Items.ForEach(item => itemList.Add(item.Name));
 
-
                 return new WindowContentGrid(
                     new[,]
                     {
@@ -62,34 +74,52 @@ namespace SolStandard.Entity.General
                                 (CanMove) ? PositiveColor : NegativeColor)
                         },
                         {
-                            new RenderText(AssetManager.WindowFont, (IsLocked) ? "Locked" : "Unlocked",
-                                (IsLocked) ? NegativeColor : PositiveColor),
-                            new RenderBlank()
-                        },
-                        {
-                            new RenderText(AssetManager.WindowFont, (IsOpen) ? "Open" : "Closed",
-                                (IsOpen) ? PositiveColor : NegativeColor),
-                            new RenderBlank()
-                        },
-                        {
-                            ObjectiveIconProvider.GetObjectiveIcon(
-                                VictoryConditions.Taxes,
-                                GameDriver.CellSizeVector
-                            ),
-                            new RenderText(AssetManager.WindowFont,
-                                (IsOpen) ? Gold + Currency.CurrencyAbbreviation : "????")
-                        },
-                        {
-                            new RenderText(AssetManager.WindowFont, "Contents: "),
-                            new RenderBlank()
-                        },
-                        {
-                            new RenderText(AssetManager.WindowFont,
-                                (IsOpen) ? string.Join(Environment.NewLine, itemList) : "????"),
+                            new Window(new WindowContentGrid(new IRenderable[,]
+                                {
+                                    {
+                                        new SpriteAtlas(
+                                            AssetManager.LockTexture,
+                                            new Vector2(AssetManager.LockTexture.Width),
+                                            GameDriver.CellSizeVector,
+                                            Convert.ToInt32(
+                                                IsLocked ? LockIconState.Locked : LockIconState.Unlocked
+                                            )
+                                        ),
+                                        new RenderText(AssetManager.WindowFont, (IsLocked) ? "Locked" : "Unlocked",
+                                            (IsLocked) ? NegativeColor : PositiveColor)
+                                    },
+                                    {
+                                        new SpriteAtlas(
+                                            AssetManager.OpenTexture,
+                                            new Vector2(AssetManager.OpenTexture.Width),
+                                            GameDriver.CellSizeVector,
+                                            Convert.ToInt32(
+                                                IsOpen ? OpenCloseIconState.Open : OpenCloseIconState.Closed
+                                            )
+                                        ),
+                                        new RenderText(AssetManager.WindowFont, (IsOpen) ? "Open" : "Closed",
+                                            (IsOpen) ? PositiveColor : NegativeColor)
+                                    },
+                                    {
+                                        ObjectiveIconProvider.GetObjectiveIcon(
+                                            VictoryConditions.Taxes,
+                                            GameDriver.CellSizeVector
+                                        ),
+                                        new RenderText(AssetManager.WindowFont,
+                                            ": " + (IsOpen ? Gold + Currency.CurrencyAbbreviation : "???"))
+                                    },
+                                    {
+                                        new RenderText(AssetManager.WindowFont, "Contents: "),
+                                        new RenderText(AssetManager.WindowFont,
+                                            (IsOpen) ? string.Join(Environment.NewLine, itemList) : "????"),
+                                    }
+                                }, 1),
+                                InnerWindowColor),
                             new RenderBlank()
                         }
                     },
-                    3
+                    3,
+                    HorizontalAlignment.Centered
                 );
             }
         }

--- a/SolStandard/Entity/General/Crossing.cs
+++ b/SolStandard/Entity/General/Crossing.cs
@@ -19,6 +19,7 @@ namespace SolStandard.Entity.General
         {
             this.crossDirection = crossDirection;
             InteractRange = new[] {1};
+            CanMove = false;
         }
 
 

--- a/SolStandard/Entity/General/Crossing.cs
+++ b/SolStandard/Entity/General/Crossing.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using SolStandard.Containers.Contexts;
+using SolStandard.Entity.Unit.Actions;
+using SolStandard.Entity.Unit.Actions.Terrain;
+using SolStandard.Map.Elements;
+using SolStandard.Utility;
+
+namespace SolStandard.Entity.General
+{
+    public class Crossing : TerrainEntity, IActionTile
+    {
+        public int[] InteractRange { get; }
+        private readonly Direction crossDirection;
+
+        public Crossing(string name, string type, IRenderable sprite, Vector2 mapCoordinates, Direction crossDirection)
+            : base(name, type, sprite, mapCoordinates)
+        {
+            this.crossDirection = crossDirection;
+            InteractRange = new[] {1};
+        }
+
+
+        public List<UnitAction> TileActions()
+        {
+            List<UnitAction> actions = new List<UnitAction>();
+
+            if (UnitOnOppositeCrossDirection(crossDirection))
+            {
+                actions.Add(new CrossAction(MapCoordinates, crossDirection));
+            }
+
+            return actions;
+        }
+
+        private bool UnitOnOppositeCrossDirection(Direction directionToCross)
+        {
+            Vector2 unitCoordinates = GameContext.ActiveUnit.UnitEntity.MapCoordinates;
+
+            switch (directionToCross)
+            {
+                case Direction.None:
+                    return UnitAction.SourceNorthOfTarget(unitCoordinates, MapCoordinates) ^
+                           UnitAction.SourceEastOfTarget(unitCoordinates, MapCoordinates) ^
+                           UnitAction.SourceSouthOfTarget(unitCoordinates, MapCoordinates) ^
+                           UnitAction.SourceWestOfTarget(unitCoordinates, MapCoordinates);
+                case Direction.Up:
+                    return UnitAction.SourceSouthOfTarget(unitCoordinates, MapCoordinates);
+                case Direction.Right:
+                    return UnitAction.SourceWestOfTarget(unitCoordinates, MapCoordinates);
+                case Direction.Down:
+                    return UnitAction.SourceNorthOfTarget(unitCoordinates, MapCoordinates);
+                case Direction.Left:
+                    return UnitAction.SourceEastOfTarget(unitCoordinates, MapCoordinates);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(directionToCross), directionToCross, null);
+            }
+        }
+    }
+}

--- a/SolStandard/Entity/General/Item/Bomb.cs
+++ b/SolStandard/Entity/General/Item/Bomb.cs
@@ -23,6 +23,7 @@ namespace SolStandard.Entity.General.Item
         public int Damage { get; }
         public IRenderable Icon { get; }
         public string ItemPool { get; }
+        public bool HasTriggered { get; set; }
         public bool IsExpired { get; private set; }
         private int turnsRemaining;
 
@@ -35,6 +36,7 @@ namespace SolStandard.Entity.General.Item
             Icon = sprite;
             ItemPool = itemPool;
             this.turnsRemaining = turnsRemaining;
+            HasTriggered = false;
             IsExpired = false;
             CanMove = false;
         }
@@ -58,7 +60,7 @@ namespace SolStandard.Entity.General.Item
 
         public bool Trigger(EffectTriggerTime triggerTime)
         {
-            if (triggerTime != EffectTriggerTime.StartOfTurn) return false;
+            if (!WillTrigger(triggerTime)) return false;
 
             turnsRemaining--;
 
@@ -106,20 +108,17 @@ namespace SolStandard.Entity.General.Item
             }
 
             MapContainer.ClearDynamicAndPreviewGrids();
-
             IsExpired = true;
-
             GameContext.GameMapContext.MapContainer.AddNewToastAtMapCellCoordinates(trapMessage, MapCoordinates,
                 50);
             AssetManager.CombatDeathSFX.Play();
-
 
             return true;
         }
 
         public bool WillTrigger(EffectTriggerTime triggerTime)
         {
-            return triggerTime == EffectTriggerTime.StartOfTurn;
+            return triggerTime == EffectTriggerTime.StartOfRound && !HasTriggered;
         }
 
         public override IRenderable TerrainInfo =>

--- a/SolStandard/Entity/General/Launchpad.cs
+++ b/SolStandard/Entity/General/Launchpad.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using SolStandard.Entity.Unit;
+using SolStandard.Entity.Unit.Actions;
+using SolStandard.Entity.Unit.Actions.Terrain;
+using SolStandard.HUD.Window;
+using SolStandard.HUD.Window.Content;
+using SolStandard.Utility;
+using SolStandard.Utility.Assets;
+
+namespace SolStandard.Entity.General
+{
+    public class Launchpad : TerrainEntity, IActionTile
+    {
+        public int[] InteractRange { get; }
+        private readonly int[] launchRange;
+
+        public Launchpad(string name, string type, Vector2 mapCoordinates, int[] launchRange) :
+            base(name, type, SpringTrap.BuildSpringSprite(SpringType.Free), mapCoordinates)
+        {
+            CanMove = true;
+            InteractRange = new[] {0};
+            this.launchRange = launchRange;
+        }
+
+        public List<UnitAction> TileActions()
+        {
+            return new List<UnitAction>
+            {
+                new LaunchpadAction(this, launchRange)
+            };
+        }
+
+        public override IRenderable TerrainInfo =>
+            new WindowContentGrid(
+                new[,]
+                {
+                    {
+                        InfoHeader,
+                        new RenderBlank()
+                    },
+                    {
+                        UnitStatistics.GetSpriteAtlas(Stats.Mv),
+                        new RenderText(AssetManager.WindowFont, (CanMove) ? "Can Move" : "No Move",
+                            (CanMove) ? PositiveColor : NegativeColor)
+                    },
+                    {
+                        new Window(
+                            new IRenderable[,]
+                            {
+                                {
+                                    UnitStatistics.GetSpriteAtlas(Stats.AtkRange),
+                                    new RenderText(AssetManager.WindowFont, "Range:"),
+                                    new RenderText(AssetManager.WindowFont, $"[{string.Join(",", InteractRange)}]")
+                                }
+                            },
+                            InnerWindowColor
+                        ),
+                        new RenderBlank()
+                    }
+                },
+                1,
+                HorizontalAlignment.Centered
+            );
+    }
+}

--- a/SolStandard/Entity/General/Piston.cs
+++ b/SolStandard/Entity/General/Piston.cs
@@ -1,0 +1,149 @@
+using System;
+using Microsoft.Xna.Framework;
+using SolStandard.Containers;
+using SolStandard.Containers.Contexts;
+using SolStandard.Entity.Unit;
+using SolStandard.Entity.Unit.Actions;
+using SolStandard.HUD.Window;
+using SolStandard.HUD.Window.Content;
+using SolStandard.Map.Elements.Cursor;
+using SolStandard.Utility;
+using SolStandard.Utility.Assets;
+
+namespace SolStandard.Entity.General
+{
+    public class Piston : TerrainEntity, IRemotelyTriggerable
+    {
+        private enum PistonDirection
+        {
+            West,
+            East,
+            South,
+            North,
+        }
+
+        private readonly PistonDirection pistonDirection;
+
+        public Piston(string name, string type, string direction, Vector2 mapCoordinates) :
+            base(name, type, BuildPistonSprite(GetPistonDirection(direction)), mapCoordinates)
+        {
+            pistonDirection = GetPistonDirection(direction);
+            CanMove = false;
+        }
+
+        private static AnimatedSpriteSheet BuildPistonSprite(PistonDirection pistonDirection)
+        {
+            const int pistonCellSize = 48;
+            AnimatedSpriteSheet sprite = new AnimatedSpriteSheet(AssetManager.PistonTexture, pistonCellSize,
+                GameDriver.CellSizeVector * 3, 6, false, Color.White);
+            sprite.SetSpriteCell(0, (int) pistonDirection);
+            sprite.Pause();
+            return sprite;
+        }
+
+        private static PistonDirection GetPistonDirection(string direction)
+        {
+            return (PistonDirection) Enum.Parse(typeof(PistonDirection), direction, true);
+        }
+
+        public void RemoteTrigger()
+        {
+            MapSlice targetSlice;
+
+            switch (pistonDirection)
+            {
+                case PistonDirection.North:
+                    targetSlice =
+                        MapContainer.GetMapSliceAtCoordinates(new Vector2(MapCoordinates.X, MapCoordinates.Y - 1));
+                    break;
+                case PistonDirection.South:
+                    targetSlice =
+                        MapContainer.GetMapSliceAtCoordinates(new Vector2(MapCoordinates.X, MapCoordinates.Y + 1));
+                    break;
+                case PistonDirection.East:
+                    targetSlice =
+                        MapContainer.GetMapSliceAtCoordinates(new Vector2(MapCoordinates.X + 1, MapCoordinates.Y));
+                    break;
+                case PistonDirection.West:
+                    targetSlice =
+                        MapContainer.GetMapSliceAtCoordinates(new Vector2(MapCoordinates.X - 1, MapCoordinates.Y));
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+
+            GameUnit targetUnit = UnitSelector.SelectUnit(targetSlice.UnitEntity);
+            if (targetUnit != null)
+            {
+                if (CanPush(targetUnit))
+                {
+                    (Sprite as AnimatedSpriteSheet)?.PlayOnce();
+                    PushTarget(targetUnit);
+                }
+                else
+                {
+                    GameContext.GameMapContext.MapContainer.AddNewToastAtMapCellCoordinates("Target is obstructed!",
+                        MapCoordinates, 50);
+                    AssetManager.WarningSFX.Play();
+                }
+            }
+            else
+            {
+                GameContext.GameMapContext.MapContainer.AddNewToastAtMapCellCoordinates("No unit in range!",
+                    MapCoordinates, 50);
+                AssetManager.WarningSFX.Play();
+            }
+        }
+
+        private bool CanPush(GameUnit targetUnit)
+        {
+            if (targetUnit == null) return false;
+
+            Vector2 targetCoordinates = targetUnit.UnitEntity.MapCoordinates;
+            Vector2 oppositeCoordinates = UnitAction.DetermineOppositeTileOfUnit(MapCoordinates, targetCoordinates);
+
+            return UnitMovingContext.CanEndMoveAtCoordinates(oppositeCoordinates) && targetUnit.IsMovable;
+        }
+
+        private void PushTarget(GameUnit target)
+        {
+            Vector2 oppositeCoordinates =
+                UnitAction.DetermineOppositeTileOfUnit(MapCoordinates, target.UnitEntity.MapCoordinates);
+            target.UnitEntity?.SlideToCoordinates(oppositeCoordinates);
+            AssetManager.CombatBlockSFX.Play();
+        }
+
+
+        public override IRenderable TerrainInfo =>
+            new WindowContentGrid(
+                new[,]
+                {
+                    {
+                        InfoHeader,
+                        new RenderBlank()
+                    },
+                    {
+                        UnitStatistics.GetSpriteAtlas(Stats.Mv),
+                        new RenderText(AssetManager.WindowFont, (CanMove) ? "Can Move" : "No Move",
+                            (CanMove) ? PositiveColor : NegativeColor)
+                    },
+                    {
+                        new Window(
+                            new IRenderable[,]
+                            {
+                                {
+                                    UnitStatistics.GetSpriteAtlas(Stats.AtkRange),
+                                    new RenderText(AssetManager.WindowFont, "Pushes: " + pistonDirection)
+                                }
+                            },
+                            InnerWindowColor
+                        ),
+                        new RenderBlank()
+                    }
+                },
+                1,
+                HorizontalAlignment.Centered
+            );
+    }
+}

--- a/SolStandard/Entity/General/Piston.cs
+++ b/SolStandard/Entity/General/Piston.cs
@@ -106,7 +106,7 @@ namespace SolStandard.Entity.General
             Vector2 targetCoordinates = targetUnit.UnitEntity.MapCoordinates;
             Vector2 oppositeCoordinates = UnitAction.DetermineOppositeTileOfUnit(MapCoordinates, targetCoordinates);
 
-            return UnitMovingContext.CanEndMoveAtCoordinates(oppositeCoordinates) && targetUnit.IsMovable;
+            return UnitMovingContext.CanEndMoveAtCoordinates(targetUnit.UnitEntity, oppositeCoordinates) && targetUnit.IsMovable;
         }
 
         private void PushTarget(GameUnit target)

--- a/SolStandard/Entity/General/Piston.cs
+++ b/SolStandard/Entity/General/Piston.cs
@@ -78,6 +78,9 @@ namespace SolStandard.Entity.General
             {
                 if (CanPush(targetUnit))
                 {
+                    GameContext.GameMapContext.MapContainer.AddNewToastAtMapCellCoordinates("PUSHING!",
+                        new Vector2(MapCoordinates.X, MapCoordinates.Y - 1),
+                        50);
                     (Sprite as AnimatedSpriteSheet)?.PlayOnce();
                     PushTarget(targetUnit);
                 }

--- a/SolStandard/Entity/General/PressurePlate.cs
+++ b/SolStandard/Entity/General/PressurePlate.cs
@@ -21,6 +21,7 @@ namespace SolStandard.Entity.General
         private readonly string triggersId;
         private bool wasPressed;
         private readonly bool triggerOnRelease;
+        public bool HasTriggered { get; set; }
         private const EffectTriggerTime TriggerTime = EffectTriggerTime.EndOfTurn;
 
         public PressurePlate(string name, string type, IRenderable sprite, Vector2 mapCoordinates, string triggersId,
@@ -30,20 +31,22 @@ namespace SolStandard.Entity.General
             this.triggersId = triggersId;
             this.triggerOnRelease = triggerOnRelease;
             wasPressed = false;
+            HasTriggered = false;
         }
 
         public bool IsExpired => false;
 
         public bool WillTrigger(EffectTriggerTime triggerTime)
         {
-            if (triggerTime != TriggerTime) return false;
+            if (triggerTime != TriggerTime || HasTriggered) return false;
 
             return ((PlateIsPressed && !wasPressed) || (!PlateIsPressed && wasPressed));
         }
 
+
         public bool Trigger(EffectTriggerTime triggerTime)
         {
-            if (triggerTime != TriggerTime) return false;
+            if (triggerTime != TriggerTime || HasTriggered) return false;
 
             if (PlateIsPressed)
             {

--- a/SolStandard/Entity/General/PressurePlate.cs
+++ b/SolStandard/Entity/General/PressurePlate.cs
@@ -51,6 +51,8 @@ namespace SolStandard.Entity.General
         {
             if (triggerTime != TriggerTime || HasTriggered) return false;
 
+            HasTriggered = true;
+
             if (PlateIsPressed)
             {
                 if ((!wasPressed || lastOccupant != CurrentOccupant) &&

--- a/SolStandard/Entity/General/PressurePlate.cs
+++ b/SolStandard/Entity/General/PressurePlate.cs
@@ -38,14 +38,14 @@ namespace SolStandard.Entity.General
         {
             if (triggerTime != TriggerTime) return false;
 
-            return ((PressurePlateIsActivated && !wasPressed) || (!PressurePlateIsActivated && ReleasingPlate));
+            return ((PlateIsPressed && !wasPressed) || (!PlateIsPressed && wasPressed));
         }
 
         public bool Trigger(EffectTriggerTime triggerTime)
         {
             if (triggerTime != TriggerTime) return false;
 
-            if (PressurePlateIsActivated)
+            if (PlateIsPressed)
             {
                 if (!wasPressed && ToggleSwitchAction.NothingObstructingSwitchTarget(TriggerTiles))
                 {
@@ -56,7 +56,7 @@ namespace SolStandard.Entity.General
             }
             else
             {
-                if (ReleasingPlate && ToggleSwitchAction.NothingObstructingSwitchTarget(TriggerTiles))
+                if (TriggeringOnRelease && ToggleSwitchAction.NothingObstructingSwitchTarget(TriggerTiles))
                 {
                     TriggerTiles.ForEach(tile => tile.RemoteTrigger());
                     AssetManager.DoorSFX.Play();
@@ -68,7 +68,7 @@ namespace SolStandard.Entity.General
             return true;
         }
 
-        private bool ReleasingPlate => wasPressed && triggerOnRelease;
+        private bool TriggeringOnRelease => wasPressed && triggerOnRelease;
 
         private List<IRemotelyTriggerable> TriggerTiles
         {
@@ -90,7 +90,7 @@ namespace SolStandard.Entity.General
             }
         }
 
-        private bool PressurePlateIsActivated => UnitIsStandingOnPressurePlate || ItemIsOnPressurePlate;
+        private bool PlateIsPressed => UnitIsStandingOnPressurePlate || ItemIsOnPressurePlate;
 
         private bool ItemIsOnPressurePlate
         {
@@ -144,7 +144,8 @@ namespace SolStandard.Entity.General
                         new RenderBlank()
                     }
                 },
-                1
+                1,
+                HorizontalAlignment.Centered
             );
 
         public bool CanTrigger => true;

--- a/SolStandard/Entity/General/RecoveryTile.cs
+++ b/SolStandard/Entity/General/RecoveryTile.cs
@@ -14,6 +14,7 @@ namespace SolStandard.Entity.General
     {
         private readonly int amrPerTurn;
         private readonly int hpPerTurn;
+        public bool HasTriggered { get; set; }
 
         public RecoveryTile(string name, string type, IRenderable sprite, Vector2 mapCoordinates, int amrPerTurn,
             int hpPerTurn) :
@@ -21,11 +22,12 @@ namespace SolStandard.Entity.General
         {
             this.amrPerTurn = amrPerTurn;
             this.hpPerTurn = hpPerTurn;
+            HasTriggered = false;
         }
 
         public bool Trigger(EffectTriggerTime triggerTime)
         {
-            if (triggerTime != EffectTriggerTime.StartOfTurn) return false;
+            if (triggerTime != EffectTriggerTime.StartOfRound || HasTriggered) return false;
 
             MapSlice recoverySlice = MapContainer.GetMapSliceAtCoordinates(MapCoordinates);
             GameUnit unitOnTile = UnitSelector.SelectUnit(recoverySlice.UnitEntity);
@@ -80,7 +82,7 @@ namespace SolStandard.Entity.General
 
         public bool WillTrigger(EffectTriggerTime triggerTime)
         {
-            if (triggerTime != EffectTriggerTime.StartOfTurn) return false;
+            if (triggerTime != EffectTriggerTime.StartOfRound || HasTriggered) return false;
 
             MapSlice recoverySlice = MapContainer.GetMapSliceAtCoordinates(MapCoordinates);
             GameUnit unitOnTile = UnitSelector.SelectUnit(recoverySlice.UnitEntity);

--- a/SolStandard/Entity/General/SpringTrap.cs
+++ b/SolStandard/Entity/General/SpringTrap.cs
@@ -23,6 +23,7 @@ namespace SolStandard.Entity.General
         public int[] InteractRange { get; }
         private readonly Vector2 trapLaunchCoordinates;
         private readonly EffectTriggerTime effectTriggerTime;
+        public bool HasTriggered { get; set; }
 
         public SpringTrap(string name, string type, Vector2 mapCoordinates, Vector2 trapLaunchCoordinates) :
             base(name, type, BuildSpringSprite(SpringType.Trap), mapCoordinates)
@@ -31,6 +32,7 @@ namespace SolStandard.Entity.General
             CanMove = true;
             InteractRange = new[] {0};
             effectTriggerTime = EffectTriggerTime.EndOfTurn;
+            HasTriggered = false;
         }
 
         public static AnimatedSpriteSheet BuildSpringSprite(SpringType springType)
@@ -45,7 +47,15 @@ namespace SolStandard.Entity.General
 
         public bool CanTrigger => UnitStandingOnSpring && !TargetTileIsObstructed;
         private bool UnitStandingOnSpring => MapContainer.GetMapSliceAtCoordinates(MapCoordinates).UnitEntity != null;
-        private bool TargetTileIsObstructed => !UnitMovingContext.CanEndMoveAtCoordinates(trapLaunchCoordinates);
+
+        private bool TargetTileIsObstructed
+        {
+            get
+            {
+                UnitEntity target = MapContainer.GetMapSliceAtCoordinates(MapCoordinates).UnitEntity;
+                return !UnitMovingContext.CanEndMoveAtCoordinates(target, trapLaunchCoordinates);
+            }
+        }
 
 
         public bool IsExpired => false;
@@ -86,7 +96,7 @@ namespace SolStandard.Entity.General
 
         public bool WillTrigger(EffectTriggerTime triggerTime)
         {
-            return effectTriggerTime == triggerTime && CanTrigger;
+            return effectTriggerTime == triggerTime && CanTrigger && !HasTriggered;
         }
 
         public void Trigger()

--- a/SolStandard/Entity/General/SpringTrap.cs
+++ b/SolStandard/Entity/General/SpringTrap.cs
@@ -68,7 +68,8 @@ namespace SolStandard.Entity.General
             {
                 UnitEntity unitEntityOnSpring = MapContainer.GetMapSliceAtCoordinates(MapCoordinates).UnitEntity;
                 GameUnit unitOnSpring = UnitSelector.SelectUnit(unitEntityOnSpring);
-
+                HasTriggered = true;
+                
                 if (!TargetTileIsObstructed)
                 {
                     GameContext.GameMapContext.MapContainer.AddNewToastAtUnit(unitEntityOnSpring,

--- a/SolStandard/Entity/General/SpringTrap.cs
+++ b/SolStandard/Entity/General/SpringTrap.cs
@@ -96,7 +96,7 @@ namespace SolStandard.Entity.General
 
         public bool WillTrigger(EffectTriggerTime triggerTime)
         {
-            return effectTriggerTime == triggerTime && CanTrigger && !HasTriggered;
+            return effectTriggerTime == triggerTime && UnitStandingOnSpring && !HasTriggered;
         }
 
         public void Trigger()

--- a/SolStandard/Entity/General/SpringTrap.cs
+++ b/SolStandard/Entity/General/SpringTrap.cs
@@ -63,6 +63,7 @@ namespace SolStandard.Entity.General
                 {
                     GameContext.GameMapContext.MapContainer.AddNewToastAtUnit(unitEntityOnSpring,
                         "LAUNCHED!", 50);
+                    (Sprite as AnimatedSpriteSheet)?.PlayOnce();
                     MoveUnitToCoordinates(unitOnSpring, trapLaunchCoordinates);
                     AssetManager.DoorSFX.Play();
                 }

--- a/SolStandard/Entity/General/SpringTrap.cs
+++ b/SolStandard/Entity/General/SpringTrap.cs
@@ -1,0 +1,133 @@
+using Microsoft.Xna.Framework;
+using SolStandard.Containers;
+using SolStandard.Containers.Contexts;
+using SolStandard.Entity.Unit;
+using SolStandard.HUD.Window;
+using SolStandard.HUD.Window.Content;
+using SolStandard.Utility;
+using SolStandard.Utility.Assets;
+using SolStandard.Utility.Events;
+using SolStandard.Utility.Events.AI;
+
+namespace SolStandard.Entity.General
+{
+    public enum SpringType
+    {
+        Free,
+        Trap,
+        Dark
+    }
+
+    public class SpringTrap : TerrainEntity, ITriggerable, IEffectTile
+    {
+        public int[] InteractRange { get; }
+        private readonly Vector2 trapLaunchCoordinates;
+        private readonly EffectTriggerTime effectTriggerTime;
+
+        public SpringTrap(string name, string type, Vector2 mapCoordinates, Vector2 trapLaunchCoordinates) :
+            base(name, type, BuildSpringSprite(SpringType.Trap), mapCoordinates)
+        {
+            this.trapLaunchCoordinates = trapLaunchCoordinates;
+            CanMove = true;
+            InteractRange = new[] {0};
+            effectTriggerTime = EffectTriggerTime.EndOfTurn;
+        }
+
+        public static AnimatedSpriteSheet BuildSpringSprite(SpringType springType)
+        {
+            const int springCellSize = 48;
+            AnimatedSpriteSheet sprite = new AnimatedSpriteSheet(AssetManager.SpringTexture, springCellSize,
+                GameDriver.CellSizeVector * 3, 6, false, Color.White);
+            sprite.SetSpriteCell(0, (int) springType);
+            sprite.Pause();
+            return sprite;
+        }
+
+        public bool CanTrigger => UnitStandingOnSpring && !TargetTileIsObstructed;
+        private bool UnitStandingOnSpring => MapContainer.GetMapSliceAtCoordinates(MapCoordinates).UnitEntity != null;
+        private bool TargetTileIsObstructed => !UnitMovingContext.CanEndMoveAtCoordinates(trapLaunchCoordinates);
+
+
+        public bool IsExpired => false;
+
+        public bool Trigger(EffectTriggerTime triggerTime)
+        {
+            if (effectTriggerTime != triggerTime) return false;
+
+            if (UnitStandingOnSpring)
+            {
+                UnitEntity unitEntityOnSpring = MapContainer.GetMapSliceAtCoordinates(MapCoordinates).UnitEntity;
+                GameUnit unitOnSpring = UnitSelector.SelectUnit(unitEntityOnSpring);
+
+                if (!TargetTileIsObstructed)
+                {
+                    GameContext.GameMapContext.MapContainer.AddNewToastAtUnit(unitEntityOnSpring,
+                        "LAUNCHED!", 50);
+                    MoveUnitToCoordinates(unitOnSpring, trapLaunchCoordinates);
+                    AssetManager.DoorSFX.Play();
+                }
+                else
+                {
+                    GameContext.GameMapContext.MapContainer.AddNewToastAtUnit(unitEntityOnSpring,
+                        "Destination is obstructed; can't launch!", 50);
+                    AssetManager.WarningSFX.Play();
+                }
+            }
+            else
+            {
+                GameContext.GameMapContext.MapContainer.AddNewToastAtMapCellCoordinates(
+                    "No unit on spring!", MapCoordinates, 50);
+                AssetManager.WarningSFX.Play();
+            }
+
+            return true;
+        }
+
+        public bool WillTrigger(EffectTriggerTime triggerTime)
+        {
+            return effectTriggerTime == triggerTime && CanTrigger;
+        }
+
+        public void Trigger()
+        {
+            GlobalEventQueue.QueueSingleEvent(new CreepEndTurnEvent());
+        }
+
+        private static void MoveUnitToCoordinates(GameUnit unitOnSpring, Vector2 targetCoordinates)
+        {
+            unitOnSpring.MoveUnitToCoordinates(targetCoordinates);
+        }
+
+
+        public override IRenderable TerrainInfo =>
+            new WindowContentGrid(
+                new[,]
+                {
+                    {
+                        InfoHeader,
+                        new RenderBlank()
+                    },
+                    {
+                        UnitStatistics.GetSpriteAtlas(Stats.Mv),
+                        new RenderText(AssetManager.WindowFont, (CanMove) ? "Can Move" : "No Move",
+                            (CanMove) ? PositiveColor : NegativeColor)
+                    },
+                    {
+                        new Window(
+                            new IRenderable[,]
+                            {
+                                {
+                                    UnitStatistics.GetSpriteAtlas(Stats.AtkRange),
+                                    new RenderText(AssetManager.WindowFont, "Target: " + trapLaunchCoordinates)
+                                }
+                            },
+                            InnerWindowColor
+                        ),
+                        new RenderBlank()
+                    }
+                },
+                1,
+                HorizontalAlignment.Centered
+            );
+    }
+}

--- a/SolStandard/Entity/General/TerrainEntity.cs
+++ b/SolStandard/Entity/General/TerrainEntity.cs
@@ -46,7 +46,8 @@ namespace SolStandard.Entity.General
         Relic,
         Piston,
         Launchpad,
-        SpringTrap
+        SpringTrap,
+        Crossing
     }
 
     public class TerrainEntity : MapEntity

--- a/SolStandard/Entity/General/TerrainEntity.cs
+++ b/SolStandard/Entity/General/TerrainEntity.cs
@@ -74,8 +74,7 @@ namespace SolStandard.Entity.General
                     new[,]
                     {
                         {
-                            new RenderText(AssetManager.WindowFont,
-                                $"X: {MapCoordinates.X}, Y: {MapCoordinates.Y}"),
+                            new RenderText(AssetManager.WindowFont, $"[ X: {MapCoordinates.X}, Y: {MapCoordinates.Y} ]"),
                             new RenderBlank()
                         },
                         {

--- a/SolStandard/Entity/General/TerrainEntity.cs
+++ b/SolStandard/Entity/General/TerrainEntity.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Xna.Framework;
-using SolStandard.Containers.Contexts;
 using SolStandard.Entity.Unit;
 using SolStandard.HUD.Window;
 using SolStandard.HUD.Window.Content;

--- a/SolStandard/Entity/General/TerrainEntity.cs
+++ b/SolStandard/Entity/General/TerrainEntity.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using SolStandard.Containers.Contexts;
 using SolStandard.Entity.Unit;
 using SolStandard.HUD.Window;
 using SolStandard.HUD.Window.Content;
@@ -44,7 +45,9 @@ namespace SolStandard.Entity.General
         RecallCharm,
         Escape,
         Relic,
-        Piston
+        Piston,
+        Launchpad,
+        SpringTrap
     }
 
     public class TerrainEntity : MapEntity
@@ -71,6 +74,11 @@ namespace SolStandard.Entity.General
                 new WindowContentGrid(
                     new[,]
                     {
+                        {
+                            new RenderText(AssetManager.WindowFont,
+                                $"X: {MapCoordinates.X}, Y: {MapCoordinates.Y}"),
+                            new RenderBlank()
+                        },
                         {
                             Sprite.Clone(),
                             NameText

--- a/SolStandard/Entity/General/TerrainEntity.cs
+++ b/SolStandard/Entity/General/TerrainEntity.cs
@@ -43,7 +43,8 @@ namespace SolStandard.Entity.General
         Contract,
         RecallCharm,
         Escape,
-        Relic
+        Relic,
+        Piston
     }
 
     public class TerrainEntity : MapEntity

--- a/SolStandard/Entity/General/TrapEntity.cs
+++ b/SolStandard/Entity/General/TrapEntity.cs
@@ -25,6 +25,7 @@ namespace SolStandard.Entity.General
         public int TriggersRemaining { get; private set; }
         public int Damage { get; }
         public string ItemPool { get; }
+        public bool HasTriggered { get; set; }
         public bool IsExpired { get; private set; }
 
         public TrapEntity(string name, IRenderable sprite, Vector2 mapCoordinates, int damage, int triggersRemaining,
@@ -38,14 +39,14 @@ namespace SolStandard.Entity.General
             this.willSnare = willSnare;
             ItemPool = itemPool;
             IsExpired = false;
+            HasTriggered = false;
 
             if (!enabled) Disable();
         }
 
         public bool Trigger(EffectTriggerTime triggerTime)
         {
-            if (triggerTime != EffectTriggerTime.StartOfTurn) return false;
-
+            if (triggerTime != EffectTriggerTime.StartOfRound || HasTriggered) return false;
             if (!enabled) return false;
 
             MapSlice trapSlice = MapContainer.GetMapSliceAtCoordinates(MapCoordinates);
@@ -94,7 +95,7 @@ namespace SolStandard.Entity.General
 
         public bool WillTrigger(EffectTriggerTime triggerTime)
         {
-            if (triggerTime != EffectTriggerTime.StartOfTurn) return false;
+            if (triggerTime != EffectTriggerTime.StartOfRound || HasTriggered) return false;
 
             MapSlice trapSlice = MapContainer.GetMapSliceAtCoordinates(MapCoordinates);
             GameUnit trapUnit = UnitSelector.SelectUnit(trapSlice.UnitEntity);

--- a/SolStandard/Entity/General/TrapEntity.cs
+++ b/SolStandard/Entity/General/TrapEntity.cs
@@ -164,7 +164,8 @@ namespace SolStandard.Entity.General
                         new RenderBlank()
                     }
                 },
-                1
+                1,
+                HorizontalAlignment.Centered
             );
 
         public UnitAction UseAction()

--- a/SolStandard/Entity/IEffectTile.cs
+++ b/SolStandard/Entity/IEffectTile.cs
@@ -4,7 +4,7 @@ namespace SolStandard.Entity
 {
     public enum EffectTriggerTime
     {
-        StartOfTurn,
+        StartOfRound,
         EndOfTurn
     }
 
@@ -12,6 +12,7 @@ namespace SolStandard.Entity
     {
         bool Trigger(EffectTriggerTime triggerTime);
         bool WillTrigger(EffectTriggerTime triggerTime);
+        bool HasTriggered { get; set; }
         bool IsExpired { get; }
         Vector2 MapCoordinates { get; }
     }

--- a/SolStandard/Entity/Unit/Actions/Creeps/BasicAttackRoutine.cs
+++ b/SolStandard/Entity/Unit/Actions/Creeps/BasicAttackRoutine.cs
@@ -81,11 +81,11 @@ namespace SolStandard.Entity.Unit.Actions.Creeps
             {
                 if (direction == Direction.None) continue;
 
-                pathAndAttackQueue.Enqueue(new UnitMoveEvent(roamer, direction));
+                pathAndAttackQueue.Enqueue(new CreepMoveEvent(roamer, direction));
                 pathAndAttackQueue.Enqueue(new WaitFramesEvent(15));
             }
 
-            pathAndAttackQueue.Enqueue(new UnitMoveEvent(roamer, Direction.None));
+            pathAndAttackQueue.Enqueue(new CreepMoveEvent(roamer, Direction.None));
             pathAndAttackQueue.Enqueue(new StartCombatEvent(targetUnitCoordinatePair.Key));
             GlobalEventQueue.QueueEvents(pathAndAttackQueue);
         }

--- a/SolStandard/Entity/Unit/Actions/Creeps/BasicAttackRoutine.cs
+++ b/SolStandard/Entity/Unit/Actions/Creeps/BasicAttackRoutine.cs
@@ -93,6 +93,8 @@ namespace SolStandard.Entity.Unit.Actions.Creeps
         protected static List<KeyValuePair<GameUnit, Vector2>> TilesWithinThreatRangeForUnit(GameUnit creep,
             bool isIndependent)
         {
+            MapContainer.ClearDynamicAndPreviewGrids();
+        
             //Check movement range
             UnitMovingContext unitMovingContext =
                 new UnitMovingContext(MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Dark));

--- a/SolStandard/Entity/Unit/Actions/Creeps/SummoningRoutine.cs
+++ b/SolStandard/Entity/Unit/Actions/Creeps/SummoningRoutine.cs
@@ -70,6 +70,7 @@ namespace SolStandard.Entity.Unit.Actions.Creeps
         {
             //This side-effect of altering the map could be icky later; keep this in mind if trying to
             //manipulate the preview layer elsewhere.
+            MapContainer.ClearDynamicAndPreviewGrids();
             List<MapElement> tilesInRange = GetTilesInRange(unitPlacingCreep.UnitEntity.MapCoordinates);
             MapContainer.ClearDynamicAndPreviewGrids();
 

--- a/SolStandard/Entity/Unit/Actions/Creeps/TreasureHunterRoutine.cs
+++ b/SolStandard/Entity/Unit/Actions/Creeps/TreasureHunterRoutine.cs
@@ -54,6 +54,7 @@ namespace SolStandard.Entity.Unit.Actions.Creeps
 
         private void SearchForTreasure()
         {
+            MapContainer.ClearDynamicAndPreviewGrids();
             GameUnit activeUnit = GameContext.ActiveUnit;
 
             if (activeUnit.UnitEntity != null && UnobstructedTreasureInRange(activeUnit))

--- a/SolStandard/Entity/Unit/Actions/Creeps/TreasureHunterRoutine.cs
+++ b/SolStandard/Entity/Unit/Actions/Creeps/TreasureHunterRoutine.cs
@@ -102,11 +102,11 @@ namespace SolStandard.Entity.Unit.Actions.Creeps
             {
                 if (direction == Direction.None) continue;
 
-                pathToItemQueue.Enqueue(new UnitMoveEvent(creep, direction));
+                pathToItemQueue.Enqueue(new CreepMoveEvent(creep, direction));
                 pathToItemQueue.Enqueue(new WaitFramesEvent(15));
             }
 
-            pathToItemQueue.Enqueue(new UnitMoveEvent(creep, Direction.None));
+            pathToItemQueue.Enqueue(new CreepMoveEvent(creep, Direction.None));
             pathToItemQueue.Enqueue(new PickUpItemEvent(itemToPickUp, itemCoordinates));
             pathToItemQueue.Enqueue(new WaitFramesEvent(50));
             GlobalEventQueue.QueueEvents(pathToItemQueue);
@@ -128,11 +128,11 @@ namespace SolStandard.Entity.Unit.Actions.Creeps
             {
                 if (direction == Direction.None) continue;
 
-                pathToCurrencyQueue.Enqueue(new UnitMoveEvent(creep, direction));
+                pathToCurrencyQueue.Enqueue(new CreepMoveEvent(creep, direction));
                 pathToCurrencyQueue.Enqueue(new WaitFramesEvent(15));
             }
 
-            pathToCurrencyQueue.Enqueue(new UnitMoveEvent(creep, Direction.None));
+            pathToCurrencyQueue.Enqueue(new CreepMoveEvent(creep, Direction.None));
             pathToCurrencyQueue.Enqueue(new PickUpCurrencyEvent(currencyToPickUp));
             pathToCurrencyQueue.Enqueue(new WaitFramesEvent(50));
             GlobalEventQueue.QueueEvents(pathToCurrencyQueue);

--- a/SolStandard/Entity/Unit/Actions/Creeps/TriggerHappyRoutine.cs
+++ b/SolStandard/Entity/Unit/Actions/Creeps/TriggerHappyRoutine.cs
@@ -68,6 +68,8 @@ namespace SolStandard.Entity.Unit.Actions.Creeps
 
         private ITriggerable FindTriggerableInRange(GameUnit creep)
         {
+            MapContainer.ClearDynamicAndPreviewGrids();
+            
             IThreatRange threatRange = new AdHocThreatRange(new[] {1}, creep.MvRange);
 
             new UnitTargetingContext(TileSprite).GenerateThreatGrid(creep.UnitEntity.MapCoordinates, threatRange);

--- a/SolStandard/Entity/Unit/Actions/Creeps/TriggerHappyRoutine.cs
+++ b/SolStandard/Entity/Unit/Actions/Creeps/TriggerHappyRoutine.cs
@@ -113,11 +113,11 @@ namespace SolStandard.Entity.Unit.Actions.Creeps
             {
                 if (direction == Direction.None) continue;
 
-                pathToItemQueue.Enqueue(new UnitMoveEvent(creep, direction));
+                pathToItemQueue.Enqueue(new CreepMoveEvent(creep, direction));
                 pathToItemQueue.Enqueue(new WaitFramesEvent(15));
             }
 
-            pathToItemQueue.Enqueue(new UnitMoveEvent(creep, Direction.None));
+            pathToItemQueue.Enqueue(new CreepMoveEvent(creep, Direction.None));
             pathToItemQueue.Enqueue(
                 new PlayAnimationAtCoordinatesEvent(AnimatedIconType.Interact, triggerable.MapCoordinates)
             );

--- a/SolStandard/Entity/Unit/Actions/Creeps/WanderRoutine.cs
+++ b/SolStandard/Entity/Unit/Actions/Creeps/WanderRoutine.cs
@@ -56,11 +56,11 @@ namespace SolStandard.Entity.Unit.Actions.Creeps
                 Direction randomDirection =
                     (Direction) GameDriver.Random.Next(1, Enum.GetValues(typeof(Direction)).Length);
 
-                roamEventQueue.Enqueue(new UnitMoveEvent(roamer, randomDirection));
+                roamEventQueue.Enqueue(new CreepMoveEvent(roamer, randomDirection));
                 roamEventQueue.Enqueue(new WaitFramesEvent(15));
             }
 
-            roamEventQueue.Enqueue(new UnitMoveEvent(roamer, Direction.None));
+            roamEventQueue.Enqueue(new CreepMoveEvent(roamer, Direction.None));
             GlobalEventQueue.QueueEvents(roamEventQueue);
         }
     }

--- a/SolStandard/Entity/Unit/Actions/DropGiveGoldAction.cs
+++ b/SolStandard/Entity/Unit/Actions/DropGiveGoldAction.cs
@@ -24,7 +24,7 @@ namespace SolStandard.Entity.Unit.Actions
             description: GenerateActionDescription(),
             tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Action),
             range: new[] {0, 1},
-            freeAction: false
+            freeAction: true
         )
         {
             Value = value;
@@ -112,7 +112,7 @@ namespace SolStandard.Entity.Unit.Actions
                     Queue<IEvent> eventQueue = new Queue<IEvent>();
                     eventQueue.Enqueue(new TransferUnitGoldEvent(actingUnit, targetUnit, Value, Icon));
                     eventQueue.Enqueue(new WaitFramesEvent(10));
-                    eventQueue.Enqueue(new EndTurnEvent());
+                    eventQueue.Enqueue(new AdditionalActionEvent());
                     GlobalEventQueue.QueueEvents(eventQueue);
                 }
                 else if (CanPlaceItemAtSlice(targetSlice))
@@ -123,7 +123,7 @@ namespace SolStandard.Entity.Unit.Actions
                         GenerateMoneyBag(targetSlice.MapCoordinates), Layer.Items, AssetManager.DropItemSFX)
                     );
                     eventQueue.Enqueue(new WaitFramesEvent(10));
-                    eventQueue.Enqueue(new EndTurnEvent());
+                    eventQueue.Enqueue(new AdditionalActionEvent());
                     GlobalEventQueue.QueueEvents(eventQueue);
                 }
                 else

--- a/SolStandard/Entity/Unit/Actions/Duelist/Shift.cs
+++ b/SolStandard/Entity/Unit/Actions/Duelist/Shift.cs
@@ -54,11 +54,11 @@ namespace SolStandard.Entity.Unit.Actions.Duelist
                 {
                     if (direction == Direction.None) continue;
 
-                    pathingEventQueue.Enqueue(new UnitMoveEvent(actingUnit, direction));
+                    pathingEventQueue.Enqueue(new CreepMoveEvent(actingUnit, direction));
                     pathingEventQueue.Enqueue(new WaitFramesEvent(5));
                 }
 
-                pathingEventQueue.Enqueue(new UnitMoveEvent(actingUnit, Direction.None));
+                pathingEventQueue.Enqueue(new CreepMoveEvent(actingUnit, Direction.None));
                 pathingEventQueue.Enqueue(new MoveEntityToCoordinatesEvent(actingUnit.UnitEntity,
                     targetSlice.MapCoordinates));
                 pathingEventQueue.Enqueue(new CameraCursorPositionEvent(targetSlice.MapCoordinates));

--- a/SolStandard/Entity/Unit/Actions/Item/DropGiveItemAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Item/DropGiveItemAction.cs
@@ -19,7 +19,7 @@ namespace SolStandard.Entity.Unit.Actions.Item
             description: "Drop this item on an empty item tile or give it to an ally.",
             tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Action),
             range: new[] {0, 1},
-            freeAction: false
+            freeAction: true
         )
         {
             this.item = item;
@@ -40,7 +40,7 @@ namespace SolStandard.Entity.Unit.Actions.Item
                 Queue<IEvent> eventQueue = new Queue<IEvent>();
                 eventQueue.Enqueue(new DropItemEvent(itemTile, targetSlice.MapCoordinates));
                 eventQueue.Enqueue(new WaitFramesEvent(10));
-                eventQueue.Enqueue(new EndTurnEvent());
+                eventQueue.Enqueue(new AdditionalActionEvent());
                 GlobalEventQueue.QueueEvents(eventQueue);
             }
             else

--- a/SolStandard/Entity/Unit/Actions/Item/TradeItemAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Item/TradeItemAction.cs
@@ -18,7 +18,7 @@ namespace SolStandard.Entity.Unit.Actions.Item
             description: "Give this item to an ally in range.",
             tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Action),
             range: new[] {0, 1},
-            freeAction: false
+            freeAction: true
         )
         {
             this.item = item;
@@ -34,7 +34,7 @@ namespace SolStandard.Entity.Unit.Actions.Item
                 Queue<IEvent> eventQueue = new Queue<IEvent>();
                 eventQueue.Enqueue(new TransferUnitItemEvent(actingUnit, targetUnit, item));
                 eventQueue.Enqueue(new WaitFramesEvent(10));
-                eventQueue.Enqueue(new EndTurnEvent());
+                eventQueue.Enqueue(new AdditionalActionEvent());
                 GlobalEventQueue.QueueEvents(eventQueue);
             }
             else

--- a/SolStandard/Entity/Unit/Actions/Mage/Blink.cs
+++ b/SolStandard/Entity/Unit/Actions/Mage/Blink.cs
@@ -37,7 +37,7 @@ namespace SolStandard.Entity.Unit.Actions.Mage
             RemoveActionTilesOnUnmovableSpaces(mapLayer);
         }
 
-        private static void RemoveActionTilesOnUnmovableSpaces(Layer mapLayer)
+        public static void RemoveActionTilesOnUnmovableSpaces(Layer mapLayer)
         {
             List<MapElement> tilesToRemove = new List<MapElement>();
 

--- a/SolStandard/Entity/Unit/Actions/Paladin/Rescue.cs
+++ b/SolStandard/Entity/Unit/Actions/Paladin/Rescue.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using SolStandard.Containers;
+using SolStandard.Containers.Contexts;
+using SolStandard.Entity.Unit.Actions.Lancer;
+using SolStandard.Map.Elements;
+using SolStandard.Map.Elements.Cursor;
+using SolStandard.Utility;
+using SolStandard.Utility.Assets;
+using SolStandard.Utility.Events;
+
+namespace SolStandard.Entity.Unit.Actions.Paladin
+{
+    public class Rescue : UnitAction
+    {
+        private enum ActionPhase
+        {
+            SelectTarget,
+            SelectLandingSpace
+        }
+
+        private ActionPhase currentPhase = ActionPhase.SelectTarget;
+        private const MapDistanceTile.TileType ActionTileType = MapDistanceTile.TileType.Action;
+
+        public Rescue() : base(
+            icon: SkillIconProvider.GetSkillIcon(SkillIcon.Rescue, GameDriver.CellSizeVector),
+            name: "Rescue",
+            description: "Leap towards an ally in need!" + Environment.NewLine +
+                         "Select a target, then select a space to land on next to that target.",
+            tileSprite: MapDistanceTile.GetTileSprite(ActionTileType),
+            range: new[] {1, 2, 3},
+            freeAction: false
+        )
+        {
+        }
+
+        public override void CancelAction()
+        {
+            currentPhase = ActionPhase.SelectTarget;
+            base.CancelAction();
+        }
+
+        public override void ExecuteAction(MapSlice targetSlice)
+        {
+            switch (currentPhase)
+            {
+                case ActionPhase.SelectTarget:
+                    if (SelectTarget(targetSlice)) currentPhase = ActionPhase.SelectLandingSpace;
+                    break;
+                case ActionPhase.SelectLandingSpace:
+                    if (SelectLandingSpace(targetSlice)) currentPhase = ActionPhase.SelectTarget;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private bool SelectTarget(MapSlice targetSlice)
+        {
+            GameUnit targetUnit = UnitSelector.SelectUnit(targetSlice.UnitEntity);
+
+            if (TargetIsAnAllyInRange(targetSlice, targetUnit))
+            {
+                if (!LeapStrike.SpaceAroundUnitIsEntirelyObstructed(targetUnit))
+                {
+                    MapContainer.ClearDynamicAndPreviewGrids();
+                    LeapStrike.CreateLandingSpacesAroundTarget(ActionTileType, targetUnit.UnitEntity.MapCoordinates);
+                    AssetManager.MenuConfirmSFX.Play();
+                    return true;
+                }
+
+                GameContext.GameMapContext.MapContainer.AddNewToastAtMapCursor("No space to land!", 50);
+                AssetManager.WarningSFX.Play();
+                return false;
+            }
+
+            GameContext.GameMapContext.MapContainer.AddNewToastAtMapCursor("Not an ally in range!", 50);
+            AssetManager.WarningSFX.Play();
+            return false;
+        }
+
+        private static bool SelectLandingSpace(MapSlice targetSlice)
+        {
+            if (targetSlice.DynamicEntity != null && !LeapStrike.CoordinatesAreObstructed(targetSlice.MapCoordinates))
+            {
+                MapContainer.ClearDynamicAndPreviewGrids();
+
+                Queue<IEvent> eventQueue = new Queue<IEvent>();
+                eventQueue.Enqueue(new WaitFramesEvent(10));
+                eventQueue.Enqueue(new MoveEntityToCoordinatesEvent(GameContext.ActiveUnit.UnitEntity,
+                    targetSlice.MapCoordinates));
+                eventQueue.Enqueue(new PlaySoundEffectEvent(AssetManager.CombatDamageSFX));
+                eventQueue.Enqueue(new WaitFramesEvent(10));
+                eventQueue.Enqueue(new EndTurnEvent());
+                GlobalEventQueue.QueueEvents(eventQueue);
+                return true;
+            }
+
+            GameContext.GameMapContext.MapContainer.AddNewToastAtMapCursor("Invalid landing space!", 50);
+            AssetManager.WarningSFX.Play();
+            return false;
+        }
+    }
+}

--- a/SolStandard/Entity/Unit/Actions/Sprint.cs
+++ b/SolStandard/Entity/Unit/Actions/Sprint.cs
@@ -65,11 +65,11 @@ namespace SolStandard.Entity.Unit.Actions
                     {
                         if (direction == Direction.None) continue;
 
-                        pathingEventQueue.Enqueue(new UnitMoveEvent(actingUnit, direction, walkThroughAllies));
+                        pathingEventQueue.Enqueue(new CreepMoveEvent(actingUnit, direction, walkThroughAllies));
                         pathingEventQueue.Enqueue(new WaitFramesEvent(5));
                     }
 
-                    pathingEventQueue.Enqueue(new UnitMoveEvent(actingUnit, Direction.None));
+                    pathingEventQueue.Enqueue(new CreepMoveEvent(actingUnit, Direction.None));
                     pathingEventQueue.Enqueue(new MoveEntityToCoordinatesEvent(actingUnit.UnitEntity,
                         targetSlice.MapCoordinates));
                     pathingEventQueue.Enqueue(new CameraCursorPositionEvent(targetSlice.MapCoordinates));

--- a/SolStandard/Entity/Unit/Actions/Terrain/CrossAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Terrain/CrossAction.cs
@@ -1,0 +1,84 @@
+using System;
+using Microsoft.Xna.Framework;
+using SolStandard.Containers;
+using SolStandard.Containers.Contexts;
+using SolStandard.Map;
+using SolStandard.Map.Elements;
+using SolStandard.Map.Elements.Cursor;
+using SolStandard.Utility.Assets;
+using SolStandard.Utility.Events;
+
+namespace SolStandard.Entity.Unit.Actions.Terrain
+{
+    public class CrossAction : UnitAction
+    {
+        private readonly Direction crossDirection;
+        private readonly Vector2 crossingOrigin;
+
+        public CrossAction(Vector2 crossingOrigin, Direction crossDirection) : base(
+            icon: SkillIconProvider.GetSkillIcon(SkillIcon.Jump, GameDriver.CellSizeVector),
+            name: "Cross",
+            description: "Cross the path.",
+            tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Action),
+            range: new[] {1},
+            freeAction: true
+        )
+        {
+            this.crossingOrigin = crossingOrigin;
+            this.crossDirection = crossDirection;
+        }
+
+        public override void GenerateActionGrid(Vector2 origin, Layer mapLayer = Layer.Dynamic)
+        {
+            Vector2 targetCoordinates = crossingOrigin;
+            switch (crossDirection)
+            {
+                case Direction.None:
+                    base.GenerateActionGrid(crossingOrigin, mapLayer);
+                    return;
+                case Direction.Up:
+                    targetCoordinates.Y -= 1;
+                    break;
+                case Direction.Right:
+                    targetCoordinates.X += 1;
+                    break;
+                case Direction.Down:
+                    targetCoordinates.Y += 1;
+                    break;
+                case Direction.Left:
+                    targetCoordinates.X -= 1;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            MapContainer.GameGrid[(int) mapLayer][(int) targetCoordinates.X, (int) targetCoordinates.Y] =
+                new MapDistanceTile(TileSprite, targetCoordinates);
+
+            GameContext.GameMapContext.MapContainer.MapCursor.SnapCursorToCoordinates(targetCoordinates);
+        }
+
+        public override void ExecuteAction(MapSlice targetSlice)
+        {
+            if (CanCrossPath(targetSlice))
+            {
+                GlobalEventQueue.QueueSingleEvent(new PlaySoundEffectEvent(AssetManager.MapUnitMoveSFX));
+                GlobalEventQueue.QueueSingleEvent(
+                    new MoveEntityToCoordinatesEvent(GameContext.ActiveUnit.UnitEntity, targetSlice.MapCoordinates)
+                );
+                GlobalEventQueue.QueueSingleEvent(new AdditionalActionEvent());
+            }
+            else
+            {
+                GameContext.GameMapContext.MapContainer.AddNewToastAtMapCursor("Cannot cross here!", 50);
+                AssetManager.WarningSFX.Play();
+            }
+        }
+
+        private static bool CanCrossPath(MapSlice targetSlice)
+        {
+            return targetSlice.DynamicEntity != null &&
+                   UnitMovingContext.CanEndMoveAtCoordinates(targetSlice.MapCoordinates);
+        }
+    }
+}

--- a/SolStandard/Entity/Unit/Actions/Terrain/LaunchpadAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Terrain/LaunchpadAction.cs
@@ -44,7 +44,7 @@ namespace SolStandard.Entity.Unit.Actions.Terrain
                 eventQueue.Enqueue(new PlayEntityAnimationOnceEvent(launchpad));
                 eventQueue.Enqueue(new MoveEntityToCoordinatesEvent(GameContext.ActiveUnit.UnitEntity,
                     targetSlice.MapCoordinates));
-                eventQueue.Enqueue(new PlaySoundEffectEvent(AssetManager.CombatDamageSFX));
+                eventQueue.Enqueue(new PlaySoundEffectEvent(AssetManager.DoorSFX));
                 eventQueue.Enqueue(new WaitFramesEvent(10));
                 eventQueue.Enqueue(new EndTurnEvent());
                 GlobalEventQueue.QueueEvents(eventQueue);

--- a/SolStandard/Entity/Unit/Actions/Terrain/LaunchpadAction.cs
+++ b/SolStandard/Entity/Unit/Actions/Terrain/LaunchpadAction.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using SolStandard.Containers.Contexts;
+using SolStandard.Entity.General;
+using SolStandard.Entity.Unit.Actions.Mage;
+using SolStandard.Map;
+using SolStandard.Map.Elements;
+using SolStandard.Map.Elements.Cursor;
+using SolStandard.Utility.Assets;
+using SolStandard.Utility.Events;
+
+namespace SolStandard.Entity.Unit.Actions.Terrain
+{
+    public class LaunchpadAction : UnitAction
+    {
+        private readonly Launchpad launchpad;
+
+        public LaunchpadAction(Launchpad launchpad, int[] range) :
+            base(
+                icon: SkillIconProvider.GetSkillIcon(SkillIcon.Jump, GameDriver.CellSizeVector),
+                name: "Launch",
+                description: "Jump to a tile in range that can be landed on.",
+                tileSprite: MapDistanceTile.GetTileSprite(MapDistanceTile.TileType.Action),
+                range: range,
+                freeAction: false
+            )
+        {
+            this.launchpad = launchpad;
+        }
+
+        public override void GenerateActionGrid(Vector2 origin, Layer mapLayer = Layer.Dynamic)
+        {
+            UnitTargetingContext unitTargetingContext = new UnitTargetingContext(TileSprite);
+            unitTargetingContext.GenerateTargetingGrid(origin, Range, mapLayer);
+            Blink.RemoveActionTilesOnUnmovableSpaces(mapLayer);
+        }
+
+        public override void ExecuteAction(MapSlice targetSlice)
+        {
+            if (CanMoveToTargetTile(targetSlice))
+            {
+                Queue<IEvent> eventQueue = new Queue<IEvent>();
+                eventQueue.Enqueue(new WaitFramesEvent(10));
+                eventQueue.Enqueue(new PlayEntityAnimationOnceEvent(launchpad));
+                eventQueue.Enqueue(new MoveEntityToCoordinatesEvent(GameContext.ActiveUnit.UnitEntity,
+                    targetSlice.MapCoordinates));
+                eventQueue.Enqueue(new PlaySoundEffectEvent(AssetManager.CombatDamageSFX));
+                eventQueue.Enqueue(new WaitFramesEvent(10));
+                eventQueue.Enqueue(new EndTurnEvent());
+                GlobalEventQueue.QueueEvents(eventQueue);
+            }
+            else
+            {
+                GameContext.GameMapContext.MapContainer.AddNewToastAtMapCursor("Can't land here!", 50);
+                AssetManager.WarningSFX.Play();
+            }
+        }
+    }
+}

--- a/SolStandard/Entity/Unit/Actions/UnitAction.cs
+++ b/SolStandard/Entity/Unit/Actions/UnitAction.cs
@@ -95,22 +95,22 @@ namespace SolStandard.Entity.Unit.Actions
                    targetSlice.DynamicEntity != null;
         }
 
-        protected static bool SourceSouthOfTarget(Vector2 sourceCoordinates, Vector2 targetCoordinates)
+        public static bool SourceSouthOfTarget(Vector2 sourceCoordinates, Vector2 targetCoordinates)
         {
             return sourceCoordinates.Y > targetCoordinates.Y;
         }
 
-        protected static bool SourceWestOfTarget(Vector2 sourceCoordinates, Vector2 targetCoordinates)
+        public static bool SourceWestOfTarget(Vector2 sourceCoordinates, Vector2 targetCoordinates)
         {
             return sourceCoordinates.X < targetCoordinates.X;
         }
 
-        protected static bool SourceEastOfTarget(Vector2 sourceCoordinates, Vector2 targetCoordinates)
+        public static bool SourceEastOfTarget(Vector2 sourceCoordinates, Vector2 targetCoordinates)
         {
             return sourceCoordinates.X > targetCoordinates.X;
         }
 
-        protected static bool SourceNorthOfTarget(Vector2 sourceCoordinates, Vector2 targetCoordinates)
+        public static bool SourceNorthOfTarget(Vector2 sourceCoordinates, Vector2 targetCoordinates)
         {
             return sourceCoordinates.Y < targetCoordinates.Y;
         }

--- a/SolStandard/Entity/Unit/CreepEntity.cs
+++ b/SolStandard/Entity/Unit/CreepEntity.cs
@@ -10,12 +10,14 @@ namespace SolStandard.Entity.Unit
     {
         private IRenderable routineIcon;
         public CreepRoutineModel Routines { get; }
+        public int StartingGold { get; }
 
         public CreepEntity(string name, string type, UnitSpriteSheet spriteSheet, Vector2 mapCoordinates, Team team,
             Role role, bool isCommander, CreepRoutineModel creepRoutineRoutines, string[] initialInventory)
             : base(name, type, spriteSheet, mapCoordinates, team, role, isCommander, initialInventory)
         {
             Routines = creepRoutineRoutines;
+            StartingGold = creepRoutineRoutines.StartingGold;
         }
 
         public void UpdateRoutineIcon(IRoutine routine)

--- a/SolStandard/Entity/Unit/UnitGenerator.cs
+++ b/SolStandard/Entity/Unit/UnitGenerator.cs
@@ -20,6 +20,8 @@ namespace SolStandard.Entity.Unit
 {
     public static class UnitGenerator
     {
+        private const int StartingGoldVariance = 5;
+
         public static List<GameUnit> GenerateUnitsFromMap(IEnumerable<UnitEntity> units, List<IItem> loot)
         {
             List<GameUnit> unitsFromMap = new List<GameUnit>();
@@ -45,7 +47,7 @@ namespace SolStandard.Entity.Unit
             {
                 generatedUnit = GenerateCreep(unitJobClass, unitTeam, id, isCommander, mapEntity as CreepEntity);
                 PopulateUnitInventory(mapEntity.InitialInventory, loot, generatedUnit);
-                AssignStartingGold(generatedUnit, ((CreepEntity) mapEntity).StartingGold, 5);
+                AssignStartingGold(generatedUnit, ((CreepEntity) mapEntity).StartingGold, StartingGoldVariance);
             }
             else
             {
@@ -346,7 +348,9 @@ namespace SolStandard.Entity.Unit
             CreepEntity generatedEntity = GenerateCreepEntity(unitName, "Creep", role, Team.Creep, false, new string[0],
                 AssetManager.UnitSprites, Vector2.Zero, entityProperties);
 
-            return GenerateCreep(role, Team.Creep, unitName, false, generatedEntity);
+            CreepUnit creep = GenerateCreep(role, Team.Creep, unitName, false, generatedEntity);
+            AssignStartingGold(creep, generatedEntity.StartingGold, StartingGoldVariance);
+            return creep;
         }
 
         public static GameUnit GenerateAdHocUnit(Role role, Team team, bool isCommander)

--- a/SolStandard/Entity/Unit/UnitGenerator.cs
+++ b/SolStandard/Entity/Unit/UnitGenerator.cs
@@ -342,7 +342,7 @@ namespace SolStandard.Entity.Unit
                 new BasicAttack(),
                 new Rampart(3, 2),
                 new Stun(1),
-                new Replace(),
+                new Rescue(),
                 new Shove(),
                 new Guard(3),
                 new Wait()

--- a/SolStandard/Entity/Unit/UnitGenerator.cs
+++ b/SolStandard/Entity/Unit/UnitGenerator.cs
@@ -57,6 +57,7 @@ namespace SolStandard.Entity.Unit
 
         private static void AssignStartingGold(GameUnit generatedUnit, int amount, int variance)
         {
+            //FIXME See if this is causing desync issues in Netplay when a creep summons another creep
             generatedUnit.CurrentGold += amount + GameDriver.Random.Next(variance);
         }
 

--- a/SolStandard/Entity/Unit/UnitGenerator.cs
+++ b/SolStandard/Entity/Unit/UnitGenerator.cs
@@ -45,7 +45,7 @@ namespace SolStandard.Entity.Unit
             {
                 generatedUnit = GenerateCreep(unitJobClass, unitTeam, id, isCommander, mapEntity as CreepEntity);
                 PopulateUnitInventory(mapEntity.InitialInventory, loot, generatedUnit);
-                AssignStartingGold(generatedUnit);
+                AssignStartingGold(generatedUnit, ((CreepEntity) mapEntity).StartingGold, 5);
             }
             else
             {
@@ -55,38 +55,9 @@ namespace SolStandard.Entity.Unit
             return generatedUnit;
         }
 
-        private static void AssignStartingGold(GameUnit generatedUnit)
+        private static void AssignStartingGold(GameUnit generatedUnit, int amount, int variance)
         {
-            switch (generatedUnit.Role)
-            {
-                case Role.Slime:
-                    generatedUnit.CurrentGold += 3 + GameDriver.Random.Next(5);
-                    break;
-                case Role.Troll:
-                    generatedUnit.CurrentGold += 14 + GameDriver.Random.Next(5);
-                    break;
-                case Role.Orc:
-                    generatedUnit.CurrentGold += 7 + GameDriver.Random.Next(8);
-                    break;
-                case Role.Necromancer:
-                    generatedUnit.CurrentGold += 14 + GameDriver.Random.Next(8);
-                    break;
-                case Role.Skeleton:
-                    generatedUnit.CurrentGold += 5 + GameDriver.Random.Next(8);
-                    break;
-                case Role.Goblin:
-                    generatedUnit.CurrentGold += 5 + GameDriver.Random.Next(8);
-                    break;
-                case Role.Rat:
-                    generatedUnit.CurrentGold += 3 + GameDriver.Random.Next(5);
-                    break;
-                case Role.Bat:
-                    generatedUnit.CurrentGold += 5 + GameDriver.Random.Next(8);
-                    break;
-                case Role.Spider:
-                    generatedUnit.CurrentGold += 3 + GameDriver.Random.Next(5);
-                    break;
-            }
+            generatedUnit.CurrentGold += amount + GameDriver.Random.Next(variance);
         }
 
         private static void PopulateUnitInventory(IEnumerable<string> inventoryItems, List<IItem> loot, GameUnit unit)
@@ -506,10 +477,10 @@ namespace SolStandard.Entity.Unit
 
         private static CreepEntity GenerateCreepEntity(string name, string type, Role role, Team team, bool isCommander,
             string[] initialInventory, List<ITexture2D> unitSprites, Vector2 mapCoordinates,
-            Dictionary<string, string> unitProperties)
+            Dictionary<string, string> creepProperties)
         {
             UnitSpriteSheet animatedSpriteSheet = GenerateUnitSpriteSheet(role, team, unitSprites);
-            CreepRoutineModel creepRoutineModel = CreepRoutineModel.GetModelForCreep(unitProperties);
+            CreepRoutineModel creepRoutineModel = CreepRoutineModel.GetModelForCreep(creepProperties);
             CreepEntity creepEntity = new CreepEntity(name, type, animatedSpriteSheet, mapCoordinates, team, role,
                 isCommander, creepRoutineModel, initialInventory);
 

--- a/SolStandard/GameDriver.cs
+++ b/SolStandard/GameDriver.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Microsoft.Xna.Framework;

--- a/SolStandard/HUD/Menu/Options/DialMenu/CopyIPAddressOption.cs
+++ b/SolStandard/HUD/Menu/Options/DialMenu/CopyIPAddressOption.cs
@@ -4,7 +4,6 @@ using SolStandard.HUD.Window;
 using SolStandard.HUD.Window.Content;
 using SolStandard.Utility;
 using SolStandard.Utility.Assets;
-using SolStandard.Utility.Monogame;
 
 namespace SolStandard.HUD.Menu.Options.DialMenu
 {

--- a/SolStandard/Map/TmxMapParser.cs
+++ b/SolStandard/Map/TmxMapParser.cs
@@ -728,6 +728,16 @@ namespace SolStandard.Map
                                             )
                                         );
                                         break;
+                                    case EntityTypes.Crossing:
+                                        entityGrid[col, row] = new Crossing(
+                                            currentObject.Name,
+                                            currentObject.Type,
+                                            tileSprite,
+                                            new Vector2(col, row),
+                                            (Direction) Enum.Parse(typeof(Direction), currentProperties["direction"],
+                                                true)
+                                        );
+                                        break;
                                     default:
                                         throw new IndexOutOfRangeException(
                                             $"Entity type {currentObject.Type} does not exist!"

--- a/SolStandard/Map/TmxMapParser.cs
+++ b/SolStandard/Map/TmxMapParser.cs
@@ -704,6 +704,10 @@ namespace SolStandard.Map
                                             currentProperties["itemPool"]
                                         );
                                         break;
+                                    case EntityTypes.Piston:
+                                        entityGrid[col, row] = new Piston(currentObject.Name, currentObject.Type,
+                                            currentProperties["direction"], new Vector2(col, row));
+                                        break;
                                     default:
                                         throw new IndexOutOfRangeException(
                                             $"Entity type {currentObject.Type} does not exist!"

--- a/SolStandard/Map/TmxMapParser.cs
+++ b/SolStandard/Map/TmxMapParser.cs
@@ -708,6 +708,26 @@ namespace SolStandard.Map
                                         entityGrid[col, row] = new Piston(currentObject.Name, currentObject.Type,
                                             currentProperties["direction"], new Vector2(col, row));
                                         break;
+                                    case EntityTypes.Launchpad:
+                                        entityGrid[col, row] = new Launchpad(
+                                            currentObject.Name,
+                                            currentObject.Type,
+                                            new Vector2(col, row),
+                                            currentProperties["radius"].Split(',').Select(n => Convert.ToInt32(n))
+                                                .ToArray()
+                                        );
+                                        break;
+                                    case EntityTypes.SpringTrap:
+                                        entityGrid[col, row] = new SpringTrap(
+                                            currentObject.Name,
+                                            currentObject.Type,
+                                            new Vector2(col, row),
+                                            new Vector2(
+                                                Convert.ToInt32(currentProperties["trigger.landingCoordinates.x"]),
+                                                Convert.ToInt32(currentProperties["trigger.landingCoordinates.y"])
+                                            )
+                                        );
+                                        break;
                                     default:
                                         throw new IndexOutOfRangeException(
                                             $"Entity type {currentObject.Type} does not exist!"

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -427,7 +427,7 @@
     <Compile Include="Utility\Events\UpdateStatusEffectEvent.cs" />
     <Compile Include="Utility\Events\AddItemToUnitInventoryEvent.cs" />
     <Compile Include="Utility\Events\AI\CreepEndTurnEvent.cs" />
-    <Compile Include="Utility\Events\AI\UnitMoveEvent.cs" />
+    <Compile Include="Utility\Events\AI\CreepMoveEvent.cs" />
     <Compile Include="Utility\Events\BlinkCoordinatesEvent.cs" />
     <Compile Include="Utility\Events\CastStatusEffectEvent.cs" />
     <Compile Include="Utility\Events\DeleteItemEvent.cs" />

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Entity\General\BreakableObstacle.cs" />
     <Compile Include="Entity\General\BuffTile.cs" />
     <Compile Include="Entity\General\Chest.cs" />
+    <Compile Include="Entity\General\Crossing.cs" />
     <Compile Include="Entity\General\Decoration.cs" />
     <Compile Include="Entity\General\DeployTile.cs" />
     <Compile Include="Entity\General\Door.cs" />
@@ -201,6 +202,7 @@
     <Compile Include="Entity\Unit\Actions\SpawnUnitAction.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\BankDeposit.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\BankWithdraw.cs" />
+    <Compile Include="Entity\Unit\Actions\Terrain\CrossAction.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\EscapeAction.cs" />
     <Compile Include="Entity\Unit\Actions\Sprint.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\LaunchpadAction.cs" />

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Entity\General\Item\Key.cs" />
     <Compile Include="Entity\General\Item\Spoils.cs" />
     <Compile Include="Entity\General\Item\WeaponStatistics.cs" />
+    <Compile Include="Entity\General\Launchpad.cs" />
     <Compile Include="Entity\General\Movable.cs" />
     <Compile Include="Entity\General\Piston.cs" />
     <Compile Include="Entity\General\Portal.cs" />
@@ -118,6 +119,7 @@
     <Compile Include="Entity\General\RecoveryTile.cs" />
     <Compile Include="Entity\General\SeizeEntity.cs" />
     <Compile Include="Entity\General\SelectMapEntity.cs" />
+    <Compile Include="Entity\General\SpringTrap.cs" />
     <Compile Include="Entity\General\Switch.cs" />
     <Compile Include="Entity\General\TerrainEntity.cs" />
     <Compile Include="Entity\General\Artillery.cs" />
@@ -201,6 +203,7 @@
     <Compile Include="Entity\Unit\Actions\Terrain\BankWithdraw.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\EscapeAction.cs" />
     <Compile Include="Entity\Unit\Actions\Sprint.cs" />
+    <Compile Include="Entity\Unit\Actions\Terrain\LaunchpadAction.cs" />
     <Compile Include="Entity\Unit\Actions\Terrain\VendorPurchase.cs" />
     <Compile Include="Entity\Unit\CreepEntity.cs" />
     <Compile Include="Entity\Unit\CreepUnit.cs" />
@@ -409,6 +412,7 @@
     <Compile Include="Utility\Events\Network\SpawnUnitEvent.cs" />
     <Compile Include="Utility\Events\Network\ToggleCombatMenuEvent.cs" />
     <Compile Include="Utility\Events\PlayAnimationAtCoordinatesEvent.cs" />
+    <Compile Include="Utility\Events\PlayEntityAnimationOnceEvent.cs" />
     <Compile Include="Utility\Events\PlaySoundEffectEvent.cs" />
     <Compile Include="Utility\Events\PreviewUnitSkillsEvent.cs" />
     <Compile Include="Utility\Events\ReadyAIRoutineEvent.cs" />

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Entity\Unit\Actions\Marauder\Guillotine.cs" />
     <Compile Include="Entity\Unit\Actions\Marauder\Rage.cs" />
     <Compile Include="Entity\Unit\Actions\Paladin\Rampart.cs" />
+    <Compile Include="Entity\Unit\Actions\Paladin\Rescue.cs" />
     <Compile Include="Entity\Unit\Actions\Paladin\Stun.cs" />
     <Compile Include="Entity\Unit\Actions\Pugilist\FlowStrike.cs" />
     <Compile Include="Entity\Unit\Actions\Pugilist\Meditate.cs" />

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -405,7 +405,7 @@
     <Compile Include="Utility\Events\Network\ResetCursorToNextUnitEvent.cs" />
     <Compile Include="Utility\Events\Network\DeployResetToNextDeploymentTileEvent.cs" />
     <Compile Include="Utility\Events\Network\ResetCursorToPreviousUnitEvent.cs" />
-    <Compile Include="Utility\Events\Network\ResolveTurnEvent.cs" />
+    <Compile Include="Utility\Events\Network\ResolveNetworkTurnEvent.cs" />
     <Compile Include="Utility\Events\Network\SelectActionMenuOptionEvent.cs" />
     <Compile Include="Utility\Events\Network\SelectMapEvent.cs" />
     <Compile Include="Utility\Events\Network\SelectUnitEvent.cs" />
@@ -419,9 +419,10 @@
     <Compile Include="Utility\Events\RemoveEntityFromMapEvent.cs" />
     <Compile Include="Utility\Events\RemoveExpiredEffectTilesEvent.cs" />
     <Compile Include="Utility\Events\RemoveStatusEffectEvent.cs" />
+    <Compile Include="Utility\Events\EffectTilesStartOfRoundEvent.cs" />
     <Compile Include="Utility\Events\UpdateTurnOrderEvent.cs" />
     <Compile Include="Utility\Events\ToastAtCursorEvent.cs" />
-    <Compile Include="Utility\Events\TriggerEffectTileEvent.cs" />
+    <Compile Include="Utility\Events\TriggerSingleEffectTileEvent.cs" />
     <Compile Include="Utility\Events\ToastAtCoordinatesEvent.cs" />
     <Compile Include="Utility\Events\UpdateStatusEffectEvent.cs" />
     <Compile Include="Utility\Events\AddItemToUnitInventoryEvent.cs" />

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -639,6 +639,9 @@
     <Content Include="Content\TmxMaps\Draft_Grassland_01.tmx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Content\TmxMaps\Draft_Hiatok_Fortress.tmx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Content\TmxMaps\Draft_Hunt_Overworld_01.tmx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -633,6 +633,9 @@
     <Content Include="Content\TmxMaps\Draft_Escape_Prison.tmx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Content\TmxMaps\Draft_Factory_Floor.tmx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Content\TmxMaps\Draft_Fortress_01.tmx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -657,6 +657,9 @@
     <Content Include="Content\TmxMaps\Draft_Master_Control.tmx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Content\TmxMaps\Draft_Quest_Race.tmx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Content\TmxMaps\Draft_Raid_Dungeon.tmx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Entity\General\Item\Spoils.cs" />
     <Compile Include="Entity\General\Item\WeaponStatistics.cs" />
     <Compile Include="Entity\General\Movable.cs" />
+    <Compile Include="Entity\General\Piston.cs" />
     <Compile Include="Entity\General\Portal.cs" />
     <Compile Include="Entity\General\PressurePlate.cs" />
     <Compile Include="Entity\General\PushBlock.cs" />

--- a/SolStandard/Utility/Assets/AssetManager.cs
+++ b/SolStandard/Utility/Assets/AssetManager.cs
@@ -51,12 +51,12 @@ namespace SolStandard.Utility.Assets
         public static ITexture2D RecoverHealthTexture { get; private set; }
         public static ITexture2D PistonTexture { get; private set; }
         public static ITexture2D SpringTexture { get; private set; }
+        public static ITexture2D LockTexture { get; private set; }
+        public static ITexture2D OpenTexture { get; private set; }
 
         public static ITexture2D MainMenuLogoTexture { get; private set; }
         public static ITexture2D MainMenuSunTexture { get; private set; }
         public static ITexture2D MainMenuBackground { get; private set; }
-        public static ITexture2D GamepadControlHelp { get; private set; }
-        public static ITexture2D KeyboardControlHelp { get; private set; }
 
         public static ISpriteFont WindowFont { get; private set; }
         public static ISpriteFont MapFont { get; private set; }
@@ -139,6 +139,8 @@ namespace SolStandard.Utility.Assets
             RecoverHealthTexture = ContentLoader.LoadRecoverHealthAtlas(content);
             PistonTexture = ContentLoader.LoadPistonAtlas(content);
             SpringTexture = ContentLoader.LoadLaunchpadAtlas(content);
+            LockTexture = ContentLoader.LoadLockAtlas(content);
+            OpenTexture = ContentLoader.LoadOpenAtlas(content);
 
             MainMenuFont = ContentLoader.LoadMainMenuFont(content);
             MainMenuLogoTexture = ContentLoader.LoadGameLogo(content);
@@ -167,9 +169,6 @@ namespace SolStandard.Utility.Assets
 
             ObjectiveIcons = ContentLoader.LoadObjectiveIcons(content);
             TeamIcons = ContentLoader.LoadTeamIcons(content);
-
-            GamepadControlHelp = ContentLoader.LoadGamepadKeyMap(content);
-            KeyboardControlHelp = ContentLoader.LoadKeyboardKeyMap(content);
 
             MenuMoveSFX = ContentLoader.LoadMenuMoveSFX(content);
             MenuConfirmSFX = ContentLoader.LoadMenuConfirmSFX(content);

--- a/SolStandard/Utility/Assets/AssetManager.cs
+++ b/SolStandard/Utility/Assets/AssetManager.cs
@@ -49,6 +49,8 @@ namespace SolStandard.Utility.Assets
         public static ITexture2D DamageTexture { get; private set; }
         public static ITexture2D RecoverArmorTexture { get; private set; }
         public static ITexture2D RecoverHealthTexture { get; private set; }
+        public static ITexture2D PistonTexture { get; private set; }
+        public static ITexture2D LaunchpadTexture { get; private set; }
 
         public static ITexture2D MainMenuLogoTexture { get; private set; }
         public static ITexture2D MainMenuSunTexture { get; private set; }
@@ -135,6 +137,8 @@ namespace SolStandard.Utility.Assets
             DamageTexture = ContentLoader.LoadDamageAtlas(content);
             RecoverArmorTexture = ContentLoader.LoadRecoverArmorAtlas(content);
             RecoverHealthTexture = ContentLoader.LoadRecoverHealthAtlas(content);
+            PistonTexture = ContentLoader.LoadPistonAtlas(content);
+            LaunchpadTexture = ContentLoader.LoadLaunchpadAtlas(content);
 
             MainMenuFont = ContentLoader.LoadMainMenuFont(content);
             MainMenuLogoTexture = ContentLoader.LoadGameLogo(content);

--- a/SolStandard/Utility/Assets/AssetManager.cs
+++ b/SolStandard/Utility/Assets/AssetManager.cs
@@ -50,7 +50,7 @@ namespace SolStandard.Utility.Assets
         public static ITexture2D RecoverArmorTexture { get; private set; }
         public static ITexture2D RecoverHealthTexture { get; private set; }
         public static ITexture2D PistonTexture { get; private set; }
-        public static ITexture2D LaunchpadTexture { get; private set; }
+        public static ITexture2D SpringTexture { get; private set; }
 
         public static ITexture2D MainMenuLogoTexture { get; private set; }
         public static ITexture2D MainMenuSunTexture { get; private set; }
@@ -138,7 +138,7 @@ namespace SolStandard.Utility.Assets
             RecoverArmorTexture = ContentLoader.LoadRecoverArmorAtlas(content);
             RecoverHealthTexture = ContentLoader.LoadRecoverHealthAtlas(content);
             PistonTexture = ContentLoader.LoadPistonAtlas(content);
-            LaunchpadTexture = ContentLoader.LoadLaunchpadAtlas(content);
+            SpringTexture = ContentLoader.LoadLaunchpadAtlas(content);
 
             MainMenuFont = ContentLoader.LoadMainMenuFont(content);
             MainMenuLogoTexture = ContentLoader.LoadGameLogo(content);

--- a/SolStandard/Utility/Assets/SkillIconProvider.cs
+++ b/SolStandard/Utility/Assets/SkillIconProvider.cs
@@ -45,7 +45,7 @@ namespace SolStandard.Utility.Assets
         LeapStrike,
         Suplex,
         Terraform,
-        
+        Rescue,
         Jump,
 
         //AI Routines
@@ -115,6 +115,7 @@ namespace SolStandard.Utility.Assets
             ITexture2D terraform = skillIconTextures.Find(texture => texture.Name.EndsWith("Terraform"));
             ITexture2D grapple = skillIconTextures.Find(texture => texture.Name.EndsWith("Grapple"));
             ITexture2D fortify = skillIconTextures.Find(texture => texture.Name.EndsWith("Fortify"));
+            ITexture2D rescue = skillIconTextures.Find(texture => texture.Name.EndsWith("Rescue"));
             ITexture2D jump = skillIconTextures.Find(texture => texture.Name.EndsWith("Jump"));
             //AI Routines
             ITexture2D prey = skillIconTextures.Find(texture => texture.Name.EndsWith("Prey"));
@@ -169,6 +170,7 @@ namespace SolStandard.Utility.Assets
                 {SkillIcon.Terraform, terraform},
                 {SkillIcon.Grapple, grapple},
                 {SkillIcon.Fortify, fortify},
+                {SkillIcon.Rescue, rescue},
                 {SkillIcon.Jump, jump},
 
                 //AI Routines

--- a/SolStandard/Utility/Assets/SkillIconProvider.cs
+++ b/SolStandard/Utility/Assets/SkillIconProvider.cs
@@ -45,6 +45,8 @@ namespace SolStandard.Utility.Assets
         LeapStrike,
         Suplex,
         Terraform,
+        
+        Jump,
 
         //AI Routines
         Prey,
@@ -113,6 +115,7 @@ namespace SolStandard.Utility.Assets
             ITexture2D terraform = skillIconTextures.Find(texture => texture.Name.EndsWith("Terraform"));
             ITexture2D grapple = skillIconTextures.Find(texture => texture.Name.EndsWith("Grapple"));
             ITexture2D fortify = skillIconTextures.Find(texture => texture.Name.EndsWith("Fortify"));
+            ITexture2D jump = skillIconTextures.Find(texture => texture.Name.EndsWith("Jump"));
             //AI Routines
             ITexture2D prey = skillIconTextures.Find(texture => texture.Name.EndsWith("Prey"));
             ITexture2D kingslayer = skillIconTextures.Find(texture => texture.Name.EndsWith("Kingslayer"));
@@ -166,6 +169,7 @@ namespace SolStandard.Utility.Assets
                 {SkillIcon.Terraform, terraform},
                 {SkillIcon.Grapple, grapple},
                 {SkillIcon.Fortify, fortify},
+                {SkillIcon.Jump, jump},
 
                 //AI Routines
                 {SkillIcon.Prey, prey},

--- a/SolStandard/Utility/Events/AI/CreepMoveEvent.cs
+++ b/SolStandard/Utility/Events/AI/CreepMoveEvent.cs
@@ -5,13 +5,13 @@ using SolStandard.Utility.Assets;
 
 namespace SolStandard.Utility.Events.AI
 {
-    public class UnitMoveEvent : IEvent
+    public class CreepMoveEvent : IEvent
     {
         private readonly GameUnit unitToMove;
         private readonly Direction directionToMove;
         private readonly bool ignoreCollision;
 
-        public UnitMoveEvent(GameUnit unitToMove, Direction directionToMove, bool ignoreCollision = false)
+        public CreepMoveEvent(GameUnit unitToMove, Direction directionToMove, bool ignoreCollision = false)
         {
             this.unitToMove = unitToMove;
             this.directionToMove = directionToMove;

--- a/SolStandard/Utility/Events/EffectTilesStartOfRoundEvent.cs
+++ b/SolStandard/Utility/Events/EffectTilesStartOfRoundEvent.cs
@@ -1,0 +1,17 @@
+using SolStandard.Containers.Contexts;
+using SolStandard.Entity;
+
+namespace SolStandard.Utility.Events
+{
+    public class EffectTilesStartOfRoundEvent : IEvent
+    {
+        public bool Complete { get; private set; }
+
+        public void Continue()
+        {
+            //IMPORTANT Do not allow tiles that have been triggered to trigger again or the risk of soft-locking via infinite triggers can occur
+            GameMapContext.TriggerEffectTiles(EffectTriggerTime.StartOfRound);
+            Complete = true;
+        }
+    }
+}

--- a/SolStandard/Utility/Events/EndTurnEvent.cs
+++ b/SolStandard/Utility/Events/EndTurnEvent.cs
@@ -1,4 +1,5 @@
 ﻿using SolStandard.Containers.Contexts;
+using SolStandard.Entity;
 
 namespace SolStandard.Utility.Events
 {
@@ -14,7 +15,11 @@ namespace SolStandard.Utility.Events
 
         public void Continue()
         {
-            GameMapContext.FinishTurn(skipProcs);
+            //IMPORTANT Do not allow tiles that have been triggered to trigger again or the risk of soft-locking via infinite triggers can occur
+            if (!GameMapContext.TriggerEffectTiles(EffectTriggerTime.EndOfTurn))
+            {
+                GameMapContext.FinishTurn(skipProcs);
+            }
 
             Complete = true;
         }

--- a/SolStandard/Utility/Events/Network/ResolveNetworkTurnEvent.cs
+++ b/SolStandard/Utility/Events/Network/ResolveNetworkTurnEvent.cs
@@ -5,7 +5,7 @@ using SolStandard.Utility.Assets;
 namespace SolStandard.Utility.Events.Network
 {
     [Serializable]
-    public class ResolveTurnEvent : NetworkEvent
+    public class ResolveNetworkTurnEvent : NetworkEvent
     {
         public override void Continue()
         {

--- a/SolStandard/Utility/Events/PlayEntityAnimationOnceEvent.cs
+++ b/SolStandard/Utility/Events/PlayEntityAnimationOnceEvent.cs
@@ -1,0 +1,21 @@
+using SolStandard.Entity.General;
+
+namespace SolStandard.Utility.Events
+{
+    public class PlayEntityAnimationOnceEvent : IEvent
+    {
+        private readonly TerrainEntity terrainEntity;
+        public bool Complete { get; private set; }
+
+        public PlayEntityAnimationOnceEvent(TerrainEntity terrainEntity)
+        {
+            this.terrainEntity = terrainEntity;
+        }
+
+        public void Continue()
+        {
+            (terrainEntity.RenderSprite as AnimatedSpriteSheet)?.PlayOnce();
+            Complete = true;
+        }
+    }
+}

--- a/SolStandard/Utility/Events/TriggerSingleEffectTileEvent.cs
+++ b/SolStandard/Utility/Events/TriggerSingleEffectTileEvent.cs
@@ -2,7 +2,7 @@ using SolStandard.Entity;
 
 namespace SolStandard.Utility.Events
 {
-    public class TriggerEffectTileEvent : IEvent
+    public class TriggerSingleEffectTileEvent : IEvent
     {
         public bool Complete { get; private set; }
         private readonly IEffectTile effectTile;
@@ -10,7 +10,8 @@ namespace SolStandard.Utility.Events
         private readonly int delayTime;
         private int delayTicker;
 
-        public TriggerEffectTileEvent(IEffectTile effectTile, EffectTriggerTime effectTriggerTime, int delayTime = 100)
+        public TriggerSingleEffectTileEvent(IEffectTile effectTile, EffectTriggerTime effectTriggerTime,
+            int delayTime = 100)
         {
             this.effectTile = effectTile;
             this.effectTriggerTime = effectTriggerTime;
@@ -27,6 +28,8 @@ namespace SolStandard.Utility.Events
                     Complete = true;
                     return;
                 }
+
+                effectTile.HasTriggered = true;
             }
 
             delayTicker--;

--- a/SolStandard/Utility/Load/ContentLoader.cs
+++ b/SolStandard/Utility/Load/ContentLoader.cs
@@ -265,6 +265,18 @@ namespace SolStandard.Utility.Load
             return new Texture2DWrapper(loadTexture);
         }
 
+        public static ITexture2D LoadLockAtlas(ContentManager content)
+        {
+            Texture2D loadTexture = content.Load<Texture2D>("Graphics/Images/Icons/Misc/Lock");
+            return new Texture2DWrapper(loadTexture);
+        }
+
+        public static ITexture2D LoadOpenAtlas(ContentManager content)
+        {
+            Texture2D loadTexture = content.Load<Texture2D>("Graphics/Images/Icons/Misc/Open");
+            return new Texture2DWrapper(loadTexture);
+        }
+
         public static ITexture2D LoadCommanderIcon(ContentManager content)
         {
             Texture2D loadTexture = content.Load<Texture2D>("Graphics/Images/Icons/Misc/CommanderCrown");
@@ -287,18 +299,6 @@ namespace SolStandard.Utility.Load
         public static ITexture2D LoadTitleScreenBackground(ContentManager content)
         {
             Texture2D loadTexture = content.Load<Texture2D>("Graphics/Images/Screens/TitleBackground_BannerStripe");
-            return new Texture2DWrapper(loadTexture);
-        }
-
-        public static ITexture2D LoadGamepadKeyMap(ContentManager content)
-        {
-            Texture2D loadTexture = content.Load<Texture2D>("Graphics/Images/Screens/ButtonMap-Xbox");
-            return new Texture2DWrapper(loadTexture);
-        }
-
-        public static ITexture2D LoadKeyboardKeyMap(ContentManager content)
-        {
-            Texture2D loadTexture = content.Load<Texture2D>("Graphics/Images/Screens/ButtonMap-PC");
             return new Texture2DWrapper(loadTexture);
         }
 
@@ -459,7 +459,7 @@ namespace SolStandard.Utility.Load
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Venom"),
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Grapple"),
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Fortify"),
-                
+
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Jump"),
                 //AI Routine Icons
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Prey"),

--- a/SolStandard/Utility/Load/ContentLoader.cs
+++ b/SolStandard/Utility/Load/ContentLoader.cs
@@ -459,6 +459,7 @@ namespace SolStandard.Utility.Load
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Venom"),
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Grapple"),
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Fortify"),
+                content.Load<Texture2D>("Graphics/Images/Icons/Skill/Rescue"),
 
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Jump"),
                 //AI Routine Icons

--- a/SolStandard/Utility/Load/ContentLoader.cs
+++ b/SolStandard/Utility/Load/ContentLoader.cs
@@ -253,6 +253,18 @@ namespace SolStandard.Utility.Load
             return new Texture2DWrapper(loadTexture);
         }
 
+        public static ITexture2D LoadPistonAtlas(ContentManager content)
+        {
+            Texture2D loadTexture = content.Load<Texture2D>("Graphics/Images/Icons/Misc/Piston");
+            return new Texture2DWrapper(loadTexture);
+        }
+
+        public static ITexture2D LoadLaunchpadAtlas(ContentManager content)
+        {
+            Texture2D loadTexture = content.Load<Texture2D>("Graphics/Images/Icons/Misc/Launchpad");
+            return new Texture2DWrapper(loadTexture);
+        }
+
         public static ITexture2D LoadCommanderIcon(ContentManager content)
         {
             Texture2D loadTexture = content.Load<Texture2D>("Graphics/Images/Icons/Misc/CommanderCrown");

--- a/SolStandard/Utility/Load/ContentLoader.cs
+++ b/SolStandard/Utility/Load/ContentLoader.cs
@@ -459,6 +459,8 @@ namespace SolStandard.Utility.Load
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Venom"),
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Grapple"),
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Fortify"),
+                
+                content.Load<Texture2D>("Graphics/Images/Icons/Skill/Jump"),
                 //AI Routine Icons
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Prey"),
                 content.Load<Texture2D>("Graphics/Images/Icons/Skill/Kingslayer"),

--- a/SolStandard/Utility/Model/CreepRoutineModel.cs
+++ b/SolStandard/Utility/Model/CreepRoutineModel.cs
@@ -32,6 +32,7 @@ namespace SolStandard.Utility.Model
         private const string IndependentProp = "Independent";
         private const string ItemsProp = "Items";
         private const string TeamProp = "Team";
+        private const string GoldProp = "gold";
         private const string FallbackRoutineProp = "fallback_routine";
         private const string RoutineBasicAttackProp = "routine_basicAttack";
         private const string RoutineSummonProp = "routine_summon";
@@ -62,17 +63,19 @@ namespace SolStandard.Utility.Model
         private readonly bool routinePrey;
         private readonly bool routineKingslayer;
         private readonly bool routineWait;
+        public int StartingGold { get; }
 
         private CreepRoutineModel(Role creepClass, bool isCommander, bool isIndependent, string items, Team team,
-            Routine fallbackRoutine, bool routineBasicAttack, bool routineSummon, string routineSummonClass,
-            bool routineWander, bool routineTreasureHunter, bool routineTriggerHappy, bool routineDefender,
-            bool routineGlutton, bool routinePrey, bool routineKingslayer, bool routineWait)
+            int startingGold, Routine fallbackRoutine, bool routineBasicAttack, bool routineSummon,
+            string routineSummonClass, bool routineWander, bool routineTreasureHunter, bool routineTriggerHappy,
+            bool routineDefender, bool routineGlutton, bool routinePrey, bool routineKingslayer, bool routineWait)
         {
             CreepClass = creepClass;
             this.isCommander = isCommander;
             this.isIndependent = isIndependent;
             this.items = items;
             this.team = team;
+            StartingGold = startingGold;
             this.fallbackRoutine = fallbackRoutine;
             this.routineBasicAttack = routineBasicAttack;
             this.routineSummon = routineSummon;
@@ -88,6 +91,7 @@ namespace SolStandard.Utility.Model
         }
 
         public List<UnitAction> Actions => GenerateCreepRoutinesFromProperties(EntityProperties);
+
 
         public IRoutine FallbackRoutine =>
             GenerateRoutine(GetRoutineByName(EntityProperties[FallbackRoutineProp]), EntityProperties) as
@@ -164,6 +168,7 @@ namespace SolStandard.Utility.Model
                 Convert.ToBoolean(unitProperties[IndependentProp]),
                 unitProperties[ItemsProp],
                 GetTeamByName(unitProperties[TeamProp]),
+                Convert.ToInt32(unitProperties[GoldProp]),
                 GetRoutineByName(unitProperties[FallbackRoutineProp]),
                 Convert.ToBoolean(unitProperties[RoutineBasicAttackProp]),
                 Convert.ToBoolean(unitProperties[RoutineSummonProp]),
@@ -215,6 +220,7 @@ namespace SolStandard.Utility.Model
                 {IndependentProp, isIndependent.ToString()},
                 {ItemsProp, items},
                 {TeamProp, team.ToString()},
+                {GoldProp, StartingGold.ToString()},
                 {FallbackRoutineProp, $"routine_{fallbackRoutine.ToString()}"},
                 {RoutineBasicAttackProp, routineBasicAttack.ToString()},
                 {RoutineSummonProp, routineSummon.ToString()},

--- a/SolStandard/Utility/TriggeredAnimation.cs
+++ b/SolStandard/Utility/TriggeredAnimation.cs
@@ -15,7 +15,7 @@ namespace SolStandard.Utility
             isVisible = false;
         }
 
-        public void PlayOnce()
+        public new void PlayOnce()
         {
             isVisible = true;
             ResetAnimation();


### PR DESCRIPTION
## Sol 43 new entities and maps

### New Maps
- Hiatok Fortress
    - Competitive Relic Map featuring Crossing tiles
- Factory Heist
    - New asymmetrical escape map featuring Pistons, Spring Traps and Launchpads
- Arctic Quest
    - Competitive PvE Relic Map where each team races to defeat their boss and collect their relic before the other team

### New entities
- Piston
- Crossing
- Launchpad
- Spring Trap

### System Enhancements
- Cascading effect tile triggers
    - If an effect tile triggers in a way that would result in a new effect tile being triggerable, that tile will now trigger and the process will scan for triggers until none remain.

### Balance Adjustments
- Replaced Paladin Replace skill with new Rescue skill
    - Allows a Paladin to jump next to an ally within range

### Bug Fixes
- Entity preview window now appears for Bombs
- Fixed desync in Netplay when a unit summons another unit with a Contract
- Creeps that are summoned by other creeps now spawn with the appropriate amount of gold
- Creeps should no longer attack beyond their range due to a preview range from a nearby unit not being cleared before scanning for targets
- Minor animation touch-ups
- Fixed crashing bug caused by previewing terrain entities during the deployment phase