### PR TITLE
Sol 56 disable creep option

### DIFF
--- a/SolStandard/Containers/Components/Global/CreepPreferences.cs
+++ b/SolStandard/Containers/Components/Global/CreepPreferences.cs
@@ -1,0 +1,33 @@
+namespace SolStandard.Containers.Components.Global
+{
+    public class CreepPreferences
+    {
+        private const string CreepPreferencesFileName = "CreepSpawn";
+
+        public bool CreepsCanSpawn { get; private set; }
+
+        public CreepPreferences()
+        {
+            LoadSavedPreferences();
+        }
+
+        private void LoadSavedPreferences()
+        {
+            if (GameDriver.FileIO.FileExists(CreepPreferencesFileName))
+            {
+                CreepsCanSpawn = GameDriver.FileIO.Load<bool>(CreepPreferencesFileName);
+            }
+            else
+            {
+                CreepsCanSpawn = true;
+                GameDriver.FileIO.Save(CreepPreferencesFileName, CreepsCanSpawn);
+            }
+        }
+
+        public void ToggleCreepsCanSpawn()
+        {
+            CreepsCanSpawn = !CreepsCanSpawn;
+            GameDriver.FileIO.Save(CreepPreferencesFileName, CreepsCanSpawn);
+        }
+    }
+}

--- a/SolStandard/Containers/Components/Global/CreepPreferences.cs
+++ b/SolStandard/Containers/Components/Global/CreepPreferences.cs
@@ -4,6 +4,7 @@ namespace SolStandard.Containers.Components.Global
     {
         private const string CreepPreferencesFileName = "CreepSpawn";
 
+        //TODO IMPORTANT Check that both players have same option selected for Netplay
         public bool CreepsCanSpawn { get; private set; }
 
         public CreepPreferences()

--- a/SolStandard/Containers/Components/Global/CreepPreferences.cs
+++ b/SolStandard/Containers/Components/Global/CreepPreferences.cs
@@ -2,12 +2,12 @@ namespace SolStandard.Containers.Components.Global
 {
     public class CreepPreferences
     {
+        public static CreepPreferences Instance { get; } = new CreepPreferences();
         private const string CreepPreferencesFileName = "CreepSpawn";
 
-        //TODO IMPORTANT Check that both players have same option selected for Netplay
         public bool CreepsCanSpawn { get; private set; }
 
-        public CreepPreferences()
+        private CreepPreferences()
         {
             LoadSavedPreferences();
         }

--- a/SolStandard/Containers/Components/Global/GlobalContext.cs
+++ b/SolStandard/Containers/Components/Global/GlobalContext.cs
@@ -60,7 +60,9 @@ namespace SolStandard.Containers.Components.Global
         public static readonly Color NegativeColor = new Color(250, 10, 10);
         public static readonly Color NeutralColor = new Color(255, 255, 255);
 
-        private static readonly string MapDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, @"Content/TmxMaps/");
+        private static readonly string MapDirectory =
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, @"Content/TmxMaps/");
+
         private const string MapSelectFile = @"Map_Select_06.tmx";
 
         public static CombatPhase CombatPhase { get; private set; }
@@ -216,6 +218,17 @@ namespace SolStandard.Containers.Components.Global
 
             CurrentGameState = GameState.InGame;
 
+            bool isSinglePlayer = Units.TrueForAll(unit => unit.Team == Team.Red || unit.Team == Team.Creep) ||
+                                  Units.TrueForAll(unit => unit.Team == Team.Blue || unit.Team == Team.Creep);
+
+            if (!isSinglePlayer && !CreepPreferences.CreepsCanSpawn)
+            {
+                foreach (GameUnit creep in Units.Where(unit => unit.Team == Team.Creep))
+                {
+                    creep.KillUnit();
+                }
+            }
+            
             foreach (GameUnit unit in Units)
             {
                 unit.ExhaustAndDisableUnit();

--- a/SolStandard/Containers/Components/Global/GlobalContext.cs
+++ b/SolStandard/Containers/Components/Global/GlobalContext.cs
@@ -82,7 +82,6 @@ namespace SolStandard.Containers.Components.Global
         public static SplashScreenContext SplashScreenContext { get; private set; }
         public static EULAContext EULAContext { get; private set; }
         public static HowToPlayContext HowToPlayContext { get; private set; }
-        public static CreepPreferences CreepPreferences { get; private set; }
 
         public static Team P1Team { get; private set; }
         public static Team P2Team => (P1Team == Team.Blue) ? Team.Red : Team.Blue;
@@ -124,7 +123,6 @@ namespace SolStandard.Containers.Components.Global
             ControlConfigContext = new ControlConfigContext(new ControlConfigView());
             StaticBackgroundView = new StaticBackgroundView();
             HowToPlayContext = new HowToPlayContext();
-            CreepPreferences = new CreepPreferences();
             LoadMapSelect();
             CurrentGameState = GameState.SplashScreen;
             P1Team = Team.Red;
@@ -221,7 +219,7 @@ namespace SolStandard.Containers.Components.Global
             bool isSinglePlayer = Units.TrueForAll(unit => unit.Team == Team.Red || unit.Team == Team.Creep) ||
                                   Units.TrueForAll(unit => unit.Team == Team.Blue || unit.Team == Team.Creep);
 
-            if (!isSinglePlayer && !CreepPreferences.CreepsCanSpawn)
+            if (!isSinglePlayer && !CreepPreferences.Instance.CreepsCanSpawn)
             {
                 foreach (GameUnit creep in Units.Where(unit => unit.Team == Team.Creep))
                 {

--- a/SolStandard/Containers/Components/Global/GlobalContext.cs
+++ b/SolStandard/Containers/Components/Global/GlobalContext.cs
@@ -80,6 +80,7 @@ namespace SolStandard.Containers.Components.Global
         public static SplashScreenContext SplashScreenContext { get; private set; }
         public static EULAContext EULAContext { get; private set; }
         public static HowToPlayContext HowToPlayContext { get; private set; }
+        public static CreepPreferences CreepPreferences { get; private set; }
 
         public static Team P1Team { get; private set; }
         public static Team P2Team => (P1Team == Team.Blue) ? Team.Red : Team.Blue;
@@ -121,6 +122,7 @@ namespace SolStandard.Containers.Components.Global
             ControlConfigContext = new ControlConfigContext(new ControlConfigView());
             StaticBackgroundView = new StaticBackgroundView();
             HowToPlayContext = new HowToPlayContext();
+            CreepPreferences = new CreepPreferences();
             LoadMapSelect();
             CurrentGameState = GameState.SplashScreen;
             P1Team = Team.Red;

--- a/SolStandard/Containers/Components/LevelSelect/MapSelectContext.cs
+++ b/SolStandard/Containers/Components/LevelSelect/MapSelectContext.cs
@@ -13,7 +13,7 @@ using SolStandard.Utility.Monogame;
 
 namespace SolStandard.Containers.Components.LevelSelect
 {
-    public class MapSelectContext 
+    public class MapSelectContext
     {
         public readonly MapSelectHUD MapSelectHUD;
         public readonly MapContainer MapContainer;
@@ -69,6 +69,14 @@ namespace SolStandard.Containers.Components.LevelSelect
                         firstTurn
                     );
 
+                    if (!GlobalContext.CreepPreferences.CreepsCanSpawn)
+                    {
+                        foreach (GameUnit creep in GlobalContext.Units.Where(unit => unit.Team == Team.Creep))
+                        {
+                            creep.KillUnit();
+                        }
+                    }
+
                     GlobalContext.DraftContext.StartNewDraft(
                         selectMapEntity.MaxBlueUnits,
                         selectMapEntity.MaxRedUnits,
@@ -76,7 +84,7 @@ namespace SolStandard.Containers.Components.LevelSelect
                         firstTurn,
                         selectMapEntity.MapObjectives.Scenario
                     );
-                    
+
                     GlobalContext.CurrentGameState = GlobalContext.GameState.ArmyDraft;
                 }
                 else
@@ -104,7 +112,7 @@ namespace SolStandard.Containers.Components.LevelSelect
                         selectMapEntity.SoloTeam,
                         selectMapEntity.MapObjectives.Scenario
                     );
-                    
+
                     GlobalContext.CurrentGameState = GlobalContext.GameState.ArmyDraft;
                 }
                 else
@@ -156,7 +164,8 @@ namespace SolStandard.Containers.Components.LevelSelect
 
         private static void PlayMapSong(SelectMapEntity mapEntity)
         {
-            IPlayableAudio songToPlay = AssetManager.MusicTracks.Find(song => song.Name.Contains(mapEntity.MapSongName));
+            IPlayableAudio songToPlay =
+                AssetManager.MusicTracks.Find(song => song.Name.Contains(mapEntity.MapSongName));
             MusicBox.PlayLoop(songToPlay);
         }
 
@@ -164,7 +173,9 @@ namespace SolStandard.Containers.Components.LevelSelect
         {
             return cursorSlice.TerrainEntity != null &&
                    cursorSlice.TerrainEntity.Type == EntityTypes.SelectMap.ToString();
-        }public void Update(GameTime gameTime)
+        }
+
+        public void Update(GameTime gameTime)
         {
             throw new NotImplementedException();
         }

--- a/SolStandard/Containers/Components/LevelSelect/MapSelectContext.cs
+++ b/SolStandard/Containers/Components/LevelSelect/MapSelectContext.cs
@@ -69,7 +69,7 @@ namespace SolStandard.Containers.Components.LevelSelect
                         firstTurn
                     );
 
-                    if (!GlobalContext.CreepPreferences.CreepsCanSpawn)
+                    if (!CreepPreferences.Instance.CreepsCanSpawn)
                     {
                         foreach (GameUnit creep in GlobalContext.Units.Where(unit => unit.Team == Team.Creep))
                         {

--- a/SolStandard/Containers/Components/Network/NetworkHUD.cs
+++ b/SolStandard/Containers/Components/Network/NetworkHUD.cs
@@ -6,6 +6,7 @@ using SolStandard.Containers.Components.MainMenu;
 using SolStandard.HUD.Menu;
 using SolStandard.HUD.Menu.Options;
 using SolStandard.HUD.Menu.Options.DialMenu;
+using SolStandard.HUD.Menu.Options.PauseMenu.ConfigMenu;
 using SolStandard.HUD.Window;
 using SolStandard.HUD.Window.Content;
 using SolStandard.Utility;
@@ -71,6 +72,11 @@ namespace SolStandard.Containers.Components.Network
                         new MainMenuOption(AssetManager.WindowFont, menuColor, this),
                         new ConnectOption(menuColor, this),
                         new PasteIPAddressOption(menuColor, this),
+                    },
+                    {
+                        new UnselectableOption(RenderBlank.Blank, menuColor),
+                        new CreepDisableOption(menuColor),
+                        new UnselectableOption(RenderBlank.Blank, menuColor),
                     }
                 },
                 new SpriteAtlas(AssetManager.MenuCursorTexture, new Vector2(AssetManager.MenuCursorTexture.Width)),
@@ -95,7 +101,10 @@ namespace SolStandard.Containers.Components.Network
                         new CopyIPAddressOption(menuColor, this),
                     },
                     {
-                        new MainMenuOption(AssetManager.MainMenuFont, menuColor, this),
+                        new CreepDisableOption(menuColor)
+                    },
+                    {
+                        new MainMenuOption(AssetManager.WindowFont, menuColor, this),
                     }
                 },
                 new SpriteAtlas(AssetManager.MenuCursorTexture, new Vector2(AssetManager.MenuCursorTexture.Width)),
@@ -147,7 +156,8 @@ namespace SolStandard.Containers.Components.Network
                 ? ""
                 : "You can get your public IP address by searching online for \"What is my IP?\"";
             const string tipText2 = "If your peer cannot connect, make sure you are both running the same major/minor version of the game.";
-            string tipText3 = $"Check to make sure you have port forwarding enabled on your router for port {ConnectionManager.NetworkPort}.";
+            string tipText3 = $"YOUR CREEP CONFIG MUST MATCH YOUR PEER. Change it in the menu below if it does not match your peer.";
+            string tipText4 = $"Check to make sure you have port forwarding enabled on your router for port {ConnectionManager.NetworkPort}.";
 
             return new Window(
                 new WindowContentGrid(
@@ -157,6 +167,7 @@ namespace SolStandard.Containers.Components.Network
                         {new RenderText(AssetManager.WindowFont, tipText1)},
                         {new RenderText(AssetManager.WindowFont, tipText2)},
                         {new RenderText(AssetManager.WindowFont, tipText3)},
+                        {new RenderText(AssetManager.WindowFont, tipText4)},
                         {new RenderText(AssetManager.MainMenuFont, statusMessage)}
                     },
                     2,

--- a/SolStandard/Containers/Components/World/SubContext/Initiative/InitiativePhase.cs
+++ b/SolStandard/Containers/Components/World/SubContext/Initiative/InitiativePhase.cs
@@ -160,7 +160,7 @@ namespace SolStandard.Containers.Components.World.SubContext.Initiative
         {
             StartNewRound();
 
-            IEnumerable<CreepUnit> creepUnits = GlobalContext.Units.Where(unit => unit is CreepUnit).Cast<CreepUnit>();
+            IEnumerable<CreepUnit> creepUnits = GlobalContext.Units.Where(unit => unit is CreepUnit && unit.IsAlive).Cast<CreepUnit>();
             foreach (CreepUnit creepUnit in creepUnits)
             {
                 creepUnit.ReadyNextRoutine();

--- a/SolStandard/Containers/Components/World/SubContext/Pause/PauseScreenUtils.cs
+++ b/SolStandard/Containers/Components/World/SubContext/Pause/PauseScreenUtils.cs
@@ -53,7 +53,8 @@ namespace SolStandard.Containers.Components.World.SubContext.Pause
                     new MusicVolumeDownOption(OptionsColor),
                     new SoundEffectMuteOption(OptionsColor),
                     new ToggleFullscreenOption(OptionsColor, gameDriver),
-                    new ReturnToPauseMenuOption(OptionsColor)
+                    new CreepDisableOption(OptionsColor),
+                    new ReturnToPauseMenuOption(OptionsColor),
                 },
                 cursorSprite,
                 OptionsColor

--- a/SolStandard/Entity/Unit/GameUnit.cs
+++ b/SolStandard/Entity/Unit/GameUnit.cs
@@ -537,6 +537,14 @@ namespace SolStandard.Entity.Unit
             };
         }
 
+        public void KillUnit()
+        {
+            Stats.CurrentArmor = 0;
+            Stats.CurrentHP = 0;
+            healthbars.ForEach(healthbar => healthbar.SetArmorAndHp(Stats.CurrentArmor, Stats.CurrentHP));
+            KillIfDead(false);
+        }
+
         public void DamageUnit(bool ignoreArmor = false)
         {
             if (Stats.CurrentArmor > 0 && !ignoreArmor)
@@ -732,7 +740,7 @@ namespace SolStandard.Entity.Unit
             return false;
         }
 
-        private void KillIfDead()
+        private void KillIfDead(bool playSfx = true)
         {
             if (Stats.CurrentHP > 0 || MapEntity == null) return;
 
@@ -742,7 +750,7 @@ namespace SolStandard.Entity.Unit
             mediumPortrait.DefaultColor = DeadPortraitColor;
             smallPortrait.DefaultColor = DeadPortraitColor;
             Logger.Debug("Unit " + Id + " is dead!");
-            AssetManager.CombatDeathSFX.Play();
+            if (playSfx) AssetManager.CombatDeathSFX.Play();
             GlobalContext.WorldContext.PlayAnimationAtCoordinates(
                 AnimatedIconProvider.GetAnimatedIcon(AnimatedIconType.Death, GameDriver.CellSizeVector),
                 MapEntity.MapCoordinates

--- a/SolStandard/GameDriver.cs
+++ b/SolStandard/GameDriver.cs
@@ -118,6 +118,7 @@ namespace SolStandard
             Window.IsBorderless = false;
             Window.AllowUserResizing = true;
         }
+        
         public static void NewGame(string mapName, Scenario scenario, Team firstTeam)
         {
             GlobalContext.StartGame(mapName, scenario, firstTeam);

--- a/SolStandard/GameDriver.cs
+++ b/SolStandard/GameDriver.cs
@@ -238,10 +238,10 @@ namespace SolStandard
             var mainMenu = new MainMenuHUD(mainMenuLogo);
             var networkMenu = new NetworkHUD(mainMenuLogo);
 
-
-            PauseScreenUtils.Initialize(this);
-
             GlobalContext.Initialize(mainMenu, networkMenu);
+            
+            PauseScreenUtils.Initialize(this);
+            
             InitializeControlMappers(GlobalContext.P1Team);
 
             ConnectionManager = new ConnectionManager();

--- a/SolStandard/HUD/Menu/Options/DialMenu/CopyIPAddressOption.cs
+++ b/SolStandard/HUD/Menu/Options/DialMenu/CopyIPAddressOption.cs
@@ -12,7 +12,7 @@ namespace SolStandard.HUD.Menu.Options.DialMenu
         private readonly NetworkHUD menu;
 
         public CopyIPAddressOption(Color menuColor, NetworkHUD menu) : base(
-            new RenderText(AssetManager.MainMenuFont, "Copy IP"),
+            new RenderText(AssetManager.WindowFont, "Copy IP"),
             menuColor,
             HorizontalAlignment.Centered
         )

--- a/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/CreepDisableOption.cs
+++ b/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/CreepDisableOption.cs
@@ -1,0 +1,30 @@
+using Microsoft.Xna.Framework;
+using SolStandard.Containers.Components.Global;
+using SolStandard.HUD.Menu.Options.MainMenu;
+using SolStandard.HUD.Window.Content;
+using SolStandard.Utility;
+using SolStandard.Utility.Assets;
+
+namespace SolStandard.HUD.Menu.Options.PauseMenu.ConfigMenu
+{
+    public class CreepDisableOption : MenuOption
+    {
+        private static string OptionText =>
+            $"Disable Creeps in Multiplayer: {!GlobalContext.CreepPreferences.CreepsCanSpawn}";
+
+        public CreepDisableOption(Color color) : base(new RenderText(AssetManager.MainMenuFont, OptionText), color)
+        {
+        }
+
+        public override void Execute()
+        {
+            GlobalContext.CreepPreferences.ToggleCreepsCanSpawn();
+            UpdateLabel(new RenderText(AssetManager.MainMenuFont, OptionText));
+        }
+
+        public override IRenderable Clone()
+        {
+            return new OpenCodexOption(DefaultColor);
+        }
+    }
+}

--- a/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/CreepDisableOption.cs
+++ b/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/CreepDisableOption.cs
@@ -9,17 +9,17 @@ namespace SolStandard.HUD.Menu.Options.PauseMenu.ConfigMenu
 {
     public class CreepDisableOption : MenuOption
     {
-        private static string OptionText =>
-            $"Disable Creeps in Multiplayer: {!GlobalContext.CreepPreferences.CreepsCanSpawn}";
+        public static string OptionText =>
+            $"Disable Creeps in 2P: <{(!CreepPreferences.Instance.CreepsCanSpawn).ToString().ToUpper()}>";
 
-        public CreepDisableOption(Color color) : base(new RenderText(AssetManager.MainMenuFont, OptionText), color)
+        public CreepDisableOption(Color color) : base(new RenderText(AssetManager.WindowFont, OptionText), color)
         {
         }
 
         public override void Execute()
         {
-            GlobalContext.CreepPreferences.ToggleCreepsCanSpawn();
-            UpdateLabel(new RenderText(AssetManager.MainMenuFont, OptionText));
+            CreepPreferences.Instance.ToggleCreepsCanSpawn();
+            UpdateLabel(new RenderText(AssetManager.WindowFont, OptionText));
         }
 
         public override IRenderable Clone()

--- a/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/MusicMuteOption.cs
+++ b/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/MusicMuteOption.cs
@@ -12,7 +12,7 @@ namespace SolStandard.HUD.Menu.Options.PauseMenu.ConfigMenu
         private const string OffLabel = "Music: Off";
 
         public MusicMuteOption(Color color) : base(
-            new RenderText(AssetManager.MainMenuFont, (MusicBox.Muted) ? OffLabel : OnLabel),
+            new RenderText(AssetManager.WindowFont, (MusicBox.Muted) ? OffLabel : OnLabel),
             color
         )
         {
@@ -21,7 +21,7 @@ namespace SolStandard.HUD.Menu.Options.PauseMenu.ConfigMenu
         public override void Execute()
         {
             MusicBox.ToggleMute();
-            UpdateLabel(new RenderText(AssetManager.MainMenuFont, (MusicBox.Muted) ? OffLabel : OnLabel));
+            UpdateLabel(new RenderText(AssetManager.WindowFont, (MusicBox.Muted) ? OffLabel : OnLabel));
         }
 
         public override IRenderable Clone()

--- a/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/MusicVolumeDownOption.cs
+++ b/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/MusicVolumeDownOption.cs
@@ -10,7 +10,7 @@ namespace SolStandard.HUD.Menu.Options.PauseMenu.ConfigMenu
     {
         private const string VolumeLabel = "Music Volume Down";
 
-        public MusicVolumeDownOption(Color color) : base(new RenderText(AssetManager.MainMenuFont, VolumeLabel), color)
+        public MusicVolumeDownOption(Color color) : base(new RenderText(AssetManager.WindowFont, VolumeLabel), color)
         {
         }
 

--- a/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/MusicVolumeUpOption.cs
+++ b/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/MusicVolumeUpOption.cs
@@ -10,7 +10,7 @@ namespace SolStandard.HUD.Menu.Options.PauseMenu.ConfigMenu
     {
         private const string VolumeLabel = "Music Volume Up";
 
-        public MusicVolumeUpOption(Color color) : base(new RenderText(AssetManager.MainMenuFont, VolumeLabel), color)
+        public MusicVolumeUpOption(Color color) : base(new RenderText(AssetManager.WindowFont, VolumeLabel), color)
         {
         }
 

--- a/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/ReturnToPauseMenuOption.cs
+++ b/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/ReturnToPauseMenuOption.cs
@@ -12,7 +12,7 @@ namespace SolStandard.HUD.Menu.Options.PauseMenu.ConfigMenu
         public static bool FromMainMenu { get; set; }
 
         public ReturnToPauseMenuOption(Color color) : base(
-            new RenderText(AssetManager.MainMenuFont, "Back"),
+            new RenderText(AssetManager.WindowFont, "Back"),
             color
         )
         {

--- a/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/SoundEffectMuteOption.cs
+++ b/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/SoundEffectMuteOption.cs
@@ -12,7 +12,7 @@ namespace SolStandard.HUD.Menu.Options.PauseMenu.ConfigMenu
         private const string OffLabel = "SFX: Off";
 
         public SoundEffectMuteOption(Color color) : base(
-            new RenderText(AssetManager.MainMenuFont, (SoundEffectWrapper.Muted) ? OffLabel : OnLabel),
+            new RenderText(AssetManager.WindowFont, (SoundEffectWrapper.Muted) ? OffLabel : OnLabel),
             color
         )
         {
@@ -22,7 +22,7 @@ namespace SolStandard.HUD.Menu.Options.PauseMenu.ConfigMenu
         {
             SoundEffectWrapper.ToggleMute();
 
-            UpdateLabel(new RenderText(AssetManager.MainMenuFont, (SoundEffectWrapper.Muted) ? OffLabel : OnLabel));
+            UpdateLabel(new RenderText(AssetManager.WindowFont, (SoundEffectWrapper.Muted) ? OffLabel : OnLabel));
         }
 
         public override IRenderable Clone()

--- a/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/ToggleFullscreenOption.cs
+++ b/SolStandard/HUD/Menu/Options/PauseMenu/ConfigMenu/ToggleFullscreenOption.cs
@@ -10,7 +10,7 @@ namespace SolStandard.HUD.Menu.Options.PauseMenu.ConfigMenu
         private readonly GameDriver gameDriver;
 
         public ToggleFullscreenOption(Color color, GameDriver gameDriver) : base(
-            new RenderText(AssetManager.MainMenuFont, "Toggle Fullscreen"), color)
+            new RenderText(AssetManager.WindowFont, "Toggle Fullscreen"), color)
         {
             this.gameDriver = gameDriver;
         }

--- a/SolStandard/HUD/Menu/Options/PauseMenu/ControlsMenu/OpenControlsMenuOption.cs
+++ b/SolStandard/HUD/Menu/Options/PauseMenu/ControlsMenu/OpenControlsMenuOption.cs
@@ -10,7 +10,7 @@ namespace SolStandard.HUD.Menu.Options.PauseMenu.ControlsMenu
     public class OpenControlsMenuOption : MenuOption
     {
         public OpenControlsMenuOption(Color color) :
-            base(new RenderText(AssetManager.MainMenuFont, "Control Config"), color)
+            base(new RenderText(AssetManager.WindowFont, "Control Config"), color)
         {
         }
 

--- a/SolStandard/SolStandard.csproj
+++ b/SolStandard/SolStandard.csproj
@@ -11,8 +11,9 @@
     <IsPackable>false</IsPackable>
     <Company>Talberon</Company>
     <Product>Sol Standard</Product>
-    <AssemblyVersion>1.1.1</AssemblyVersion>
+    <AssemblyVersion>1.2.0</AssemblyVersion>
     <NeutralLanguage>en</NeutralLanguage>
+    <PackageVersion>1.2.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SolStandard/Utility/Network/ConnectionManager.cs
+++ b/SolStandard/Utility/Network/ConnectionManager.cs
@@ -20,12 +20,9 @@ namespace SolStandard.Utility.Network
 
         private NetServer server;
         private NetClient client;
-        private readonly string appIdentifier;
 
-        public ConnectionManager()
-        {
-            appIdentifier = $"Sol Standard {GameDriver.VersionNumber}";
-        }
+        private static string AppIdentifier => $"Sol Standard v{GameDriver.VersionNumber} // " +
+                                               $"CreepsEnabled:{CreepPreferences.Instance.CreepsCanSpawn}";
 
         public const int NetworkPort = 1993;
 
@@ -39,7 +36,7 @@ namespace SolStandard.Utility.Network
         {
             StopClientAndServer();
 
-            var config = new NetPeerConfiguration(appIdentifier)
+            var config = new NetPeerConfiguration(AppIdentifier)
             {
                 Port = NetworkPort,
                 EnableUPnP = true
@@ -74,7 +71,7 @@ namespace SolStandard.Utility.Network
         {
             StopClientAndServer();
 
-            var config = new NetPeerConfiguration(appIdentifier);
+            var config = new NetPeerConfiguration(AppIdentifier);
 
             Logger.Debug("Starting client!");
             client = new NetClient(config);


### PR DESCRIPTION
Added configuration to game that allows destroying all of the creeps on multiplayer maps as it loads to allow players to focus on fighting each other instead of the AI if desired.